### PR TITLE
Add toolchain setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This repository experiments with running a language model on Nintendo 64 hardwar
 The Rust code is the focus for new features. All crates are built with
 `no_std` and target `mips-nintendo64-none`.
 
+## Environment setup
+
+If you are preparing a fresh system, the commands required to install the
+Rust and MIPS toolchains are listed in [docs/setup.md](docs/setup.md). Follow
+those steps to enable full debugging and testing on your machine.
+
 ## Building the Rust project
 
 A custom toolchain is required. Install [`cargo-n64`](https://github.com/rust-console/cargo-n64) and add the `mips-nintendo64-none` target:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,45 @@
+# Development Environment Setup
+
+This guide lists the commands needed to install the toolchains used by the N64Soul project.
+These instructions assume a Unix-like host with `bash` and `git` installed.
+
+## Rust toolchain
+
+Install Rust using [`rustup`](https://rustup.rs/) if it is not already available:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Then add the Nintendo 64 target and install `cargo-n64`:
+
+```bash
+rustup target add mips-nintendo64-none
+cargo install cargo-n64
+```
+
+## Libdragon MIPS toolchain (for C examples)
+
+Clone the libdragon repository and build its cross compiler:
+
+```bash
+git clone https://github.com/dragonminded/libdragon.git
+cd libdragon
+make toolchain
+```
+
+After the build completes, add the toolchain to your `PATH`:
+
+```bash
+export PATH="$PWD/mips64-elf/bin:$PATH"
+```
+
+## Emulator
+
+For local testing you can install an N64 emulator such as **Mupen64Plus**. On Debian-based systems:
+
+```bash
+sudo apt-get install mupen64plus
+```
+
+You can then run generated ROMs with `mupen64plus <path-to-rom>`.


### PR DESCRIPTION
## Summary
- document install commands for full environment setup in `docs/setup.md`
- mention new setup instructions in the README

## Testing
- `cargo --version`


------
https://chatgpt.com/codex/tasks/task_e_6865b7908444832384bddadc975913ff