### PR TITLE
Add weight validation hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Validate model weights if they were modified in this commit
+FILES="$(git diff --cached --name-only)"
+if echo "$FILES" | grep -q "n64llm/n64-rust/src/n64_model_weights_reduced.bin"; then
+    echo "Running n64llm/validate_weights.py..."
+    python3 n64llm/validate_weights.py || {
+        echo "Weight validation failed. Aborting commit." >&2
+        exit 1
+    }
+fi
+

--- a/README.md
+++ b/README.md
@@ -90,3 +90,16 @@ The script prints an error if any section in `n64_model_weights_reduced.bin`
 does not align with the offsets and sizes defined in
 `n64llm/n64-rust/src/inference_engine.rs`. The constants are parsed directly
 from the Rust source so the check always reflects the current build.
+
+### Git hook for automatic validation
+
+To ensure this validation runs whenever model weights are updated, a sample
+pre-commit hook is provided in `.githooks/pre-commit`. Enable it with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+With the hook active, any commit that modifies
+`n64llm/n64-rust/src/n64_model_weights_reduced.bin` will automatically invoke
+`validate_weights.py` and abort the commit if the offsets do not match.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 - [x] Document how to run the project in an emulator and on hardware.
 - [x] Add memory usage diagnostics using `available_memory()` at key runtime points.
 - [x] Exercise `Error` variants in `inference_engine` to test error handling.
-- [ ] Ensure `validate_weights.py` is run whenever model weights change.
+- [x] Ensure `validate_weights.py` is run whenever model weights change.
 - [x] Add controller input logging for debugging purposes.
 - [x] Enable host-side unit tests for tokenizer and math routines.
 - [x] Document the full toolchain setup in the README.

--- a/n64llm/exportmodel.py
+++ b/n64llm/exportmodel.py
@@ -104,3 +104,11 @@ total_bytes = total_floats * 2
 print(f"🔹 Total floats exported: {total_floats}")
 print(f"🔹 Total binary size: {total_bytes / (1024*1024):.2f} MB")
 print(f"✅ Export completed! Weights saved to '{OUTPUT_FILENAME}'.")
+
+# Validate the produced weight file against the Rust constants.
+print("🔹 Validating exported weights...")
+script_dir = os.path.dirname(os.path.realpath(__file__))
+validate_script = os.path.join(script_dir, "validate_weights.py")
+ret = os.system(f"python3 {validate_script}")
+if ret != 0:
+    raise SystemExit("Weight validation failed. Please check the export script.")


### PR DESCRIPTION
## Summary
- run `validate_weights.py` automatically after exporting
- add git pre-commit hook for weight validation
- document how to enable the hook
- mark TODO item completed

## Testing
- `python3 n64llm/validate_weights.py`
- `python3 -m py_compile n64llm/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6865dc998fb48323881944c828181800