### PR TITLE
Add docs sidebar prototype

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>N64Soul Documentation</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>N64Soul Documentation</h1>
+    </header>
+    <main>
+        <article>
+            <h2>Welcome</h2>
+            <p>This is a placeholder documentation page for the project.</p>
+        </article>
+    </main>
+    <aside class="sidebar">
+        <h2>Topics</h2>
+        <ul class="toc">
+            <li>Setup</li>
+            <li>
+                Building
+                <ul>
+                    <li>Rust Project</li>
+                    <li>C Examples</li>
+                </ul>
+            </li>
+            <li>Running</li>
+        </ul>
+        <h2>Last Updated</h2>
+        <time>May 26, 2025</time>
+    </aside>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,43 @@
+body {
+    display: grid;
+    grid-template-columns: 1fr 250px;
+    gap: 2rem;
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 1rem;
+}
+
+header {
+    grid-column: 1 / -1;
+}
+
+.sidebar {
+    position: sticky;
+    top: 2rem;
+    align-self: start;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 250px;
+}
+
+.sidebar .toc {
+    list-style: none;
+    padding-left: 0;
+}
+
+.sidebar .toc ul {
+    margin-top: 0.25rem;
+    margin-left: 1rem;
+    list-style: disc;
+}
+
+.sidebar h2 {
+    margin-bottom: 0.25rem;
+    font-size: 1rem;
+}
+
+.sidebar time {
+    font-size: 0.9rem;
+    color: #555;
+}


### PR DESCRIPTION
## Summary
- create placeholder docs site with `index.html`
- add `styles.css` to replicate blog sidebar layout

## Testing
- `python3 n64llm/validate_weights.py`

------
https://chatgpt.com/codex/tasks/task_e_6865ea8ba7b48323b041fbaeae13e771