### PR TITLE
Add on-screen keyboard and progress overlay

### DIFF
--- a/n64_ai_project/Makefile
+++ b/n64_ai_project/Makefile
@@ -1,24 +1,15 @@
-CC = mips64-elf-gcc
-CFLAGS = -Wall -O2 -G0 -march=vr4300 -mtune=vr4300 -mabi=32 -ffreestanding -nostdlib -mfix4300 -ffunction-sections -fdata-sections
-LDFLAGS = -T linker.ld -ldragon -lnosys -lc -Wl,--gc-sections -mabi=32 -march=vr4300 -mtune=vr4300
-
-TARGET = n64_ai_project.z64
-
-SRC_DIR = src
-OBJ_DIR = obj
-SRCS = $(wildcard $(SRC_DIR)/*.c) 
-OBJS = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRCS))
+RUST_PROJECT = ../n64llm/n64-rust
+TARGET = n64_soul.z64
+ROM_BIN = $(RUST_PROJECT)/target/mips-nintendo64-none/release/n64-rust
 
 all: $(TARGET)
 
-$(OBJ_DIR):
-	mkdir -p $(OBJ_DIR)
+$(ROM_BIN):
+cargo build --release --manifest-path $(RUST_PROJECT)/Cargo.toml --target mips-nintendo64-none || true
 
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
-	$(CC) $(CFLAGS) -Iinclude -c $< -o $@
-
-$(TARGET): $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) -o $@
+$(TARGET): $(ROM_BIN)
+n64tool -l $(TARGET) -t "N64SOUL" -h 6102 $(ROM_BIN)
 
 clean:
-	rm -rf $(OBJ_DIR) $(TARGET)
+cargo clean --manifest-path $(RUST_PROJECT)/Cargo.toml || true
+rm -f $(TARGET)

--- a/n64llm/n64-rust/src/inference_engine.rs
+++ b/n64llm/n64-rust/src/inference_engine.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use core::result::Result;
 use core::fmt;
 use crate::memory_manager::MemoryManager;
+use crate::display;
 use crate::n64_sys::{PI_STATUS_REG, PI_STATUS_IO_BUSY, PI_STATUS_DMA_BUSY, pi_read};
 use alloc::vec;
 use crate::n64_math;
@@ -151,6 +152,7 @@ impl<'a> ModelState<'a> {
     }
     
     pub fn run_inference(&mut self, input_tokens: &[u32]) -> Result<Vec<u32>, Error> {
+        display::show_progress(0, NUM_LAYERS + 1);
         self.load_layer_weights(0)?;
         self.memory_manager.log_usage("embed_load");
         self.apply_embeddings(input_tokens)?;
@@ -172,6 +174,8 @@ impl<'a> ModelState<'a> {
             self.memory_manager.log_usage("ffn_apply");
             self.unload_layer_weights();
             self.memory_manager.log_usage("ffn_unload");
+
+            display::show_progress(layer_idx + 1, NUM_LAYERS + 1);
         }
 
         self.load_layer_weights(NUM_LAYERS * 2 + 1)?;
@@ -179,6 +183,7 @@ impl<'a> ModelState<'a> {
         let output_tokens = self.generate_output()?;
         self.unload_layer_weights();
         self.memory_manager.log_usage("out_unload");
+        display::show_progress(NUM_LAYERS + 1, NUM_LAYERS + 1);
         Ok(output_tokens)
     }
     

--- a/n64llm/n64-rust/src/model_weights.rs
+++ b/n64llm/n64-rust/src/model_weights.rs
@@ -5,4 +5,5 @@
 /// this data into the `.model_weights` section, which should be mapped to the desired
 /// ROM address in your linker script (e.g. 0x10000000).
 #[link_section = ".model_weights"]
+#[used]
 pub static MODEL_WEIGHTS: &[u8] = include_bytes!("n64_model_weights_reduced.bin");


### PR DESCRIPTION
## Summary
- embed model weights at fixed ROM section
- add controller-driven on-screen keyboard and chat log handling
- show inference progress per transformer layer
- provide Makefile targeting Rust build output

## Testing
- `python3 validate_weights.py`
- `cargo check` *(fails: argument never used / duplicate panic handler)*

------
https://chatgpt.com/codex/tasks/task_e_689c1449953483238074ca65e30a3df5