### PR TITLE
Add ROM probe diagnostic

### DIFF
--- a/n64llm/n64-rust/src/diag/mod.rs
+++ b/n64llm/n64-rust/src/diag/mod.rs
@@ -1,0 +1,1 @@
+pub mod rom_probe;

--- a/n64llm/n64-rust/src/diag/rom_probe.rs
+++ b/n64llm/n64-rust/src/diag/rom_probe.rs
@@ -1,0 +1,15 @@
+pub fn rom_probe(read_from_rom: impl Fn(u64, &mut [u8]) -> bool) {
+    let mut buf = [0u8; 64];
+    let probe_offsets = [
+        16 * 1024 * 1024u64,          // 16 MiB
+        256 * 1024 * 1024u64,         // 256 MiB
+        480 * 1024 * 1024u64,         // 480 MiB (below the ~500 MiB limit)
+    ];
+
+    for &off in &probe_offsets {
+        let ok = read_from_rom(off, &mut buf);
+        // Draw to screen/log: print offset and first 8 bytes hex
+        // If any read fails, print a big red “X” so it’s obvious.
+        crate::display::log_probe(off, ok, &buf[..8]);
+    }
+}

--- a/n64llm/n64-rust/src/display.rs
+++ b/n64llm/n64-rust/src/display.rs
@@ -3,6 +3,7 @@
 
 use alloc::string::String;
 use alloc::format;
+use core::fmt::Write;
 use crate::n64_sys;
 
 // N64 display buffer address (adjust for real hardware)
@@ -426,6 +427,15 @@ pub fn show_progress(current: usize, total: usize) {
         }
     }
     print_line(&format!("Working... [{}] {}/{}", bar, current, total));
+}
+
+pub fn log_probe(offset: u64, ok: bool, first_bytes: &[u8]) {
+    let mut hex = String::new();
+    for &b in first_bytes {
+        let _ = write!(hex, "{:02X}", b);
+    }
+    let status = if ok { "OK" } else { "X" };
+    print_line(&format!("probe 0x{:08X}: {} {}", offset, hex, status));
 }
 
 // Scroll the display up by one character row

--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -16,6 +16,7 @@ mod inference_engine;
 mod tokenizer;
 mod display;
 mod memory_manager;
+mod diag;
 
 #[no_mangle]
 pub extern "C" fn main() -> ! {
@@ -24,6 +25,18 @@ pub extern "C" fn main() -> ! {
     display::clear();
     display::print_line("N64 GPT - Flash-Streamed AI Model");
     display::print_line("Initializing...");
+
+    display::print_line("Probing ROM...");
+    diag::rom_probe::rom_probe(|off, buf| {
+        unsafe {
+            n64_sys::pi_read(
+                buf.as_mut_ptr(),
+                (n64_sys::CART_ROM_BASE as u32).wrapping_add(off as u32),
+                buf.len() as u32,
+            );
+        }
+        true
+    });
 
     // Initialize memory management system.
     let mut memory = unsafe { memory_manager::init() };


### PR DESCRIPTION
## Summary
- Add ROM probing helper to exercise high ROM offsets via PI reads
- Log probe results on-screen for easy visibility during boot
- Invoke ROM probe during initialization to verify firmware mapping

## Testing
- `cargo check --target mips64-unknown-elf` *(fails: could not find specification for target)*
- `cargo check --target mips64-unknown-none` *(fails: could not find specification for target)*
- `cargo check --target mips-nintendo64-none` *(fails: could not find specification for target)*

------
https://chatgpt.com/codex/tasks/task_e_689d0850ee348323b0c8e3c39178940d