### PR TITLE
Add ROM weight section symbols and tooling

### DIFF
--- a/n64llm/assets/.gitignore
+++ b/n64llm/assets/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated weight blob
+weights.bin

--- a/n64llm/assets/weights.manifest.json
+++ b/n64llm/assets/weights.manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "align": 64,
+  "layers": []
+}

--- a/n64llm/n64-rust/n64.ld
+++ b/n64llm/n64-rust/n64.ld
@@ -6,8 +6,8 @@ ENTRY(_start)
 MEMORY
 {
     /* ROM region: This is where your code, constants, and model weights reside.
-       Adjust LENGTH to match your cartridge size. Here we assume 32 MB. */
-    ROM (rx)  : ORIGIN = 0x10000000, LENGTH = 32M
+       Adjust LENGTH to match your cartridge size. Here we assume ~480 MB. */
+    ROM (rx)  : ORIGIN = 0x10000000, LENGTH = 480M
 
     /* RDRAM region: Base N64 has 4 MB of RAM.
        All writable data (.data, .bss, heap, stack) live here. */
@@ -28,14 +28,13 @@ SECTIONS
         *(.rodata*)
     } > ROM
 
-    /* .model_weights: Dedicated section for model weights.
-       This section is explicitly placed at 0x10000000.
-       When you embed your weights file using a #[link_section] attribute,
-       its contents will be placed here. */
-    .model_weights 0x10000000 : ALIGN(4)
+    /* .model_weights: Dedicated section for model weights. */
+    __model_weights_rom_start = .;
+    .model_weights ALIGN(64) :
     {
-         KEEP(*(.model_weights))
+         KEEP(*(.model_weights*))
     } > ROM
+    __model_weights_rom_end = .;
 
     /* .data: Initialized mutable data goes into RDRAM */
     .data : ALIGN(4)

--- a/n64llm/n64-rust/src/model_weights.rs
+++ b/n64llm/n64-rust/src/model_weights.rs
@@ -1,9 +1,25 @@
 #![no_std]
 
-/// This static variable embeds the entire model weights binary into the ROM image.
-/// The `#[link_section = ".model_weights"]` attribute tells the linker to place
-/// this data into the `.model_weights` section, which should be mapped to the desired
-/// ROM address in your linker script (e.g. 0x10000000).
 #[link_section = ".model_weights"]
+#[no_mangle]
 #[used]
-pub static MODEL_WEIGHTS: &[u8] = include_bytes!("n64_model_weights_reduced.bin");
+pub static MODEL_WEIGHTS: [u8; include_bytes!("../../assets/weights.bin").len()] =
+    *include_bytes!("../../assets/weights.bin");
+
+extern "C" {
+    static __model_weights_rom_start: u8;
+    static __model_weights_rom_end: u8;
+}
+
+#[inline(always)]
+pub fn weights_rom_base() -> usize {
+    unsafe { &__model_weights_rom_start as *const u8 as usize }
+}
+
+#[inline(always)]
+pub fn weights_rom_size() -> usize {
+    unsafe {
+        (&__model_weights_rom_end as *const u8 as usize)
+            - (&__model_weights_rom_start as *const u8 as usize)
+    }
+}

--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Export model weights to a contiguous blob with manifest.
+
+Usage:
+    python export_model.py name1=path1 name2=path2 ...
+Each argument specifies a layer name and the path to its raw weights.
+The script concatenates the files into `weights.bin` with 64-byte alignment
+and writes `weights.manifest.json` describing the layout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ALIGN = 64
+
+
+def pad_size(size: int, align: int = ALIGN) -> int:
+    return (size + align - 1) // align * align
+
+
+def write_aligned(f, data: bytes) -> tuple[int, int]:
+    offset = f.tell()
+    pad = (-offset) % ALIGN
+    if pad:
+        f.write(b"\0" * pad)
+        offset += pad
+    padded = pad_size(len(data))
+    f.write(data)
+    if padded > len(data):
+        f.write(b"\0" * (padded - len(data)))
+    return offset, padded
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create weights.bin and manifest")
+    parser.add_argument("segments", nargs="+", help="Layer segments in name=path form")
+    parser.add_argument(
+        "--outdir",
+        default=Path(__file__).resolve().parent.parent / "n64llm" / "assets",
+        type=Path,
+        help="Output directory for weights.bin and manifest",
+    )
+    args = parser.parse_args()
+
+    outdir: Path = args.outdir
+    outdir.mkdir(parents=True, exist_ok=True)
+    weights_path = outdir / "weights.bin"
+    manifest_path = outdir / "weights.manifest.json"
+
+    layers = []
+    with weights_path.open("wb") as wf:
+        for spec in args.segments:
+            if "=" not in spec:
+                raise SystemExit(f"Invalid segment spec '{spec}', expected name=path")
+            name, path = spec.split("=", 1)
+            data = Path(path).read_bytes()
+            offset, size = write_aligned(wf, data)
+            layers.append({"name": name, "offset": offset, "size": size})
+    manifest = {"version": 1, "align": ALIGN, "layers": layers}
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    print(f"wrote {weights_path} ({weights_path.stat().st_size} bytes)")
+    print(f"wrote {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_weights.py
+++ b/tools/validate_weights.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate a weights.bin file against its manifest."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate weights manifest")
+    default_dir = Path(__file__).resolve().parent.parent / "n64llm" / "assets"
+    parser.add_argument("--weights", type=Path, default=default_dir / "weights.bin")
+    parser.add_argument(
+        "--manifest", type=Path, default=default_dir / "weights.manifest.json"
+    )
+    args = parser.parse_args()
+
+    if not args.weights.exists():
+        print(f"missing weights file: {args.weights}")
+        return 1
+    if not args.manifest.exists():
+        print(f"missing manifest: {args.manifest}")
+        return 1
+
+    data = json.loads(args.manifest.read_text())
+    align = data.get("align", 64)
+    layers = data.get("layers", [])
+    file_size = args.weights.stat().st_size
+
+    last_end = 0
+    total = 0
+    for layer in layers:
+        name = layer["name"]
+        off = layer["offset"]
+        size = layer["size"]
+        if off % align != 0:
+            print(f"layer {name} offset {off} not aligned to {align}")
+            return 1
+        if off < last_end:
+            print(f"layer {name} overlaps previous segment")
+            return 1
+        end = off + size
+        if end > file_size:
+            print(f"layer {name} exceeds file size")
+            return 1
+        last_end = end
+        total += size
+
+    if total != file_size:
+        print(f"sum of layer sizes {total} != file size {file_size}")
+        return 1
+
+    print("weights and manifest validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extend linker ROM region to ~480MB and export model weight section symbols
- embed weights.bin via `.model_weights` section with start/end helpers
- add asset manifest placeholder and python tools to export and validate weight blobs

## Testing
- `python tools/export_model.py --outdir /tmp/wassets tok=/etc/hosts`
- `python tools/validate_weights.py --weights /tmp/wassets/weights.bin --manifest /tmp/wassets/weights.manifest.json`
- `cargo check` *(fails: argument never used; requires N64 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_689d0d13a1e08323897a0ec9905547b8