### PR TITLE
Add ROM reader and configuration scaffolding

### DIFF
--- a/n64llm/n64-rust/src/config.rs
+++ b/n64llm/n64-rust/src/config.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+pub const BURST_BYTES: usize = 32 * 1024; // Try 16K, 32K, 64K
+pub const ROM_ALIGN: usize = 64;          // Exporter enforces; reader asserts
+pub const PROBE_OFFSETS: &[u64] = &[
+    16 * 1024 * 1024,
+    256 * 1024 * 1024,
+    480 * 1024 * 1024,
+];
+pub const ENABLE_DOUBLE_BUFFER: bool = true;
+pub const UI_BURSTS_PER_REFRESH: usize = 4;
+// Maximum ROM bytes to treat as readable (e.g., firmware cap)
+pub const ROM_LIMIT_BYTES: u64 = 480 * 1024 * 1024;

--- a/n64llm/n64-rust/src/diag/rom_probe.rs
+++ b/n64llm/n64-rust/src/diag/rom_probe.rs
@@ -1,12 +1,8 @@
+use crate::config::PROBE_OFFSETS;
+
 pub fn rom_probe(read_from_rom: impl Fn(u64, &mut [u8]) -> bool) {
     let mut buf = [0u8; 64];
-    let probe_offsets = [
-        16 * 1024 * 1024u64,          // 16 MiB
-        256 * 1024 * 1024u64,         // 256 MiB
-        480 * 1024 * 1024u64,         // 480 MiB (below the ~500 MiB limit)
-    ];
-
-    for &off in &probe_offsets {
+    for &off in PROBE_OFFSETS {
         let ok = read_from_rom(off, &mut buf);
         // Draw to screen/log: print offset and first 8 bytes hex
         // If any read fails, print a big red “X” so it’s obvious.

--- a/n64llm/n64-rust/src/io/dbuf.rs
+++ b/n64llm/n64-rust/src/io/dbuf.rs
@@ -1,0 +1,25 @@
+pub struct Dbuf<const N: usize> {
+    a: [u8; N],
+    b: [u8; N],
+    use_a: bool,
+}
+
+impl<const N: usize> Dbuf<N> {
+    pub const fn new() -> Self {
+        Self {
+            a: [0; N],
+            b: [0; N],
+            use_a: true,
+        }
+    }
+
+    pub fn pair(&mut self) -> (&mut [u8; N], &mut [u8; N]) {
+        if self.use_a {
+            self.use_a = false;
+            (&mut self.a, &mut self.b)
+        } else {
+            self.use_a = true;
+            (&mut self.b, &mut self.a)
+        }
+    }
+}

--- a/n64llm/n64-rust/src/io/mod.rs
+++ b/n64llm/n64-rust/src/io/mod.rs
@@ -1,0 +1,2 @@
+pub mod dbuf;
+pub mod rom_reader;

--- a/n64llm/n64-rust/src/io/rom_reader.rs
+++ b/n64llm/n64-rust/src/io/rom_reader.rs
@@ -1,0 +1,39 @@
+use crate::{config, n64_sys};
+
+pub trait RomReader {
+    /// Reads `dst.len()` bytes from absolute ROM offset.
+    /// Returns false on failure (OOB, DMA error, etc.)
+    fn read(&mut self, rom_abs_off: u64, dst: &mut [u8]) -> bool;
+    fn rom_limit_bytes(&self) -> u64; // for diagnostic prints
+}
+
+pub struct FlatRomReader;
+
+impl RomReader for FlatRomReader {
+    fn read(&mut self, mut off: u64, mut dst: &mut [u8]) -> bool {
+        if off % config::ROM_ALIGN as u64 != 0 {
+            return false;
+        }
+        if off + dst.len() as u64 > self.rom_limit_bytes() {
+            return false;
+        }
+        while !dst.is_empty() {
+            let chunk = core::cmp::min(dst.len(), config::BURST_BYTES);
+            unsafe {
+                n64_sys::pi_read(
+                    dst.as_mut_ptr(),
+                    (n64_sys::CART_ROM_BASE as u32).wrapping_add(off as u32),
+                    chunk as u32,
+                );
+            }
+            off += chunk as u64;
+            let tmp = dst;
+            dst = &mut tmp[chunk..];
+        }
+        true
+    }
+
+    fn rom_limit_bytes(&self) -> u64 {
+        config::ROM_LIMIT_BYTES
+    }
+}

--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -2,21 +2,23 @@
 #![no_main]
 
 extern crate alloc;
+mod config;
+mod ipl3;
 mod model_weights;
 mod n64_math;
 mod n64_sys;
-mod ipl3;
 
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::panic::PanicInfo;
-use alloc::format;
 
-mod inference_engine;
-mod tokenizer;
-mod display;
-mod memory_manager;
 mod diag;
+mod display;
+mod inference_engine;
+mod io;
+mod memory_manager;
+mod tokenizer;
 
 #[no_mangle]
 pub extern "C" fn main() -> ! {


### PR DESCRIPTION
## Summary
- centralize ROM tuning constants in new `config` module
- use shared probe offsets for `rom_probe`
- add double-buffer helper and flat ROM reader trait for DMA streaming

## Testing
- `cargo check` *(fails: argument never used; missing weights.bin; duplicate lang item)*
- `python tools/validate_weights.py` *(fails: missing weights file)*

------
https://chatgpt.com/codex/tasks/task_e_689d0eab3f0483239a7e75dd6f885687