### PR TITLE
Use manifest to drive layer loading

### DIFF
--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -19,6 +19,7 @@ mod inference_engine;
 mod io;
 mod memory_manager;
 mod tokenizer;
+mod manifest;
 
 #[no_mangle]
 pub extern "C" fn main() -> ! {
@@ -40,6 +41,9 @@ pub extern "C" fn main() -> ! {
         true
     });
 
+    let manifest = manifest::load();
+    display::print_line(&format!("Manifest layers: {}", manifest.layers.len()));
+
     // Initialize memory management system.
     let mut memory = unsafe { memory_manager::init() };
     display::print_line("Memory manager initialized");
@@ -60,7 +64,7 @@ pub extern "C" fn main() -> ! {
                 let input_tokens = tokenizer.encode(&input_buffer);
 
                 let output_tokens = match {
-                    let mut engine = inference_engine::ModelState::new(&mut memory);
+                    let mut engine = inference_engine::ModelState::new(&mut memory, &manifest);
                     engine.run_inference(&input_tokens)
                 } {
                     Ok(tokens) => tokens,

--- a/n64llm/n64-rust/src/manifest.rs
+++ b/n64llm/n64-rust/src/manifest.rs
@@ -1,0 +1,63 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[derive(Debug, Clone)]
+pub struct Layer {
+    pub name: String,
+    pub offset: u32,
+    pub size: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct Manifest {
+    pub layers: Vec<Layer>,
+}
+
+pub fn load() -> Manifest {
+    let json = include_str!("../../assets/weights.manifest.json");
+    parse(json)
+}
+
+fn parse(json: &str) -> Manifest {
+    let mut layers = Vec::new();
+    if let Some(start) = json.find('[') {
+        let mut rest = &json[start + 1..];
+        while let Some(obj_start) = rest.find('{') {
+            rest = &rest[obj_start + 1..];
+            if let Some(obj_end) = rest.find('}') {
+                let obj = &rest[..obj_end];
+                rest = &rest[obj_end + 1..];
+                let mut name = String::new();
+                let mut offset = 0u32;
+                let mut size = 0u32;
+                for field in obj.split(',') {
+                    let mut parts = field.splitn(2, ':');
+                    let key = parts
+                        .next()
+                        .unwrap_or("")
+                        .trim()
+                        .trim_matches(|c| c == '"');
+                    let value = parts.next().unwrap_or("").trim();
+                    match key {
+                        "name" => {
+                            name = value.trim_matches('"').to_string();
+                        }
+                        "offset" => {
+                            offset = value.parse().unwrap_or(0);
+                        }
+                        "size" => {
+                            size = value.parse().unwrap_or(0);
+                        }
+                        _ => {}
+                    }
+                }
+                if !name.is_empty() {
+                    layers.push(Layer { name, offset, size });
+                }
+            } else {
+                break;
+            }
+        }
+    }
+    Manifest { layers }
+}


### PR DESCRIPTION
## Summary
- parse `weights.manifest.json` at runtime
- load model layers using manifest offsets instead of hardcoded tables
- wire manifest loading into startup so inference engine receives it

## Testing
- `cargo check` *(fails: argument never used, missing weights.bin, experimental `#[naked]`)*
- `python tools/validate_weights.py`

------
https://chatgpt.com/codex/tasks/task_e_689d1037a62c832389085457e9ef5f3c