### PR TITLE
Add ROM layer streaming helper

### DIFF
--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -20,6 +20,7 @@ mod io;
 mod memory_manager;
 mod tokenizer;
 mod manifest;
+mod model;
 
 #[no_mangle]
 pub extern "C" fn main() -> ! {

--- a/n64llm/n64-rust/src/model/mod.rs
+++ b/n64llm/n64-rust/src/model/mod.rs
@@ -1,0 +1,1 @@
+pub mod stream;

--- a/n64llm/n64-rust/src/model/stream.rs
+++ b/n64llm/n64-rust/src/model/stream.rs
@@ -1,0 +1,54 @@
+use crate::{
+    config,
+    io::{dbuf::Dbuf, rom_reader::RomReader},
+    manifest::Manifest,
+    model_weights::weights_rom_base,
+};
+
+/// Streams a model layer from ROM using a [`RomReader`] and double buffering.
+/// Calls `on_chunk` for each chunk of data read.
+/// Returns `false` on any read error.
+pub fn stream_layer<R: RomReader, F>(
+    rr: &mut R,
+    manifest: &Manifest,
+    layer_idx: usize,
+    mut on_chunk: F,
+) -> bool
+where
+    F: FnMut(&[u8]),
+{
+    if layer_idx >= manifest.layers.len() {
+        return false;
+    }
+
+    let layer = &manifest.layers[layer_idx];
+    let mut off = layer.offset as u64 + weights_rom_base() as u64;
+    let mut remain = layer.size as u64;
+
+    const BURST: usize = config::BURST_BYTES;
+    let mut dbuf: Dbuf<BURST> = Dbuf::new();
+    let (mut cur, mut nxt) = dbuf.pair();
+
+    let first = core::cmp::min(remain as usize, BURST);
+    if !rr.read(off, &mut cur[..first]) {
+        return false;
+    }
+    off += first as u64;
+    remain -= first as u64;
+    let mut cur_len = first;
+
+    while remain > 0 {
+        let to_read = core::cmp::min(remain as usize, BURST);
+        if !rr.read(off, &mut nxt[..to_read]) {
+            return false;
+        }
+        on_chunk(&cur[..cur_len]);
+        core::mem::swap(&mut cur, &mut nxt);
+        cur_len = to_read;
+        off += to_read as u64;
+        remain -= to_read as u64;
+    }
+
+    on_chunk(&cur[..cur_len]);
+    true
+}


### PR DESCRIPTION
## Summary
- add `stream_layer` helper for double-buffered ROM reads
- expose `model` module in main for future streaming work

## Testing
- `cargo fmt --all -- --check` *(fails: formatting differences in existing files)*
- `python tools/validate_weights.py` *(fails: missing weights.bin)*

------
https://chatgpt.com/codex/tasks/task_e_689d118adf8c83239daa5eedccb3ff02