### PR TITLE
Add ROM checksum dry run via streaming

### DIFF
--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -45,6 +45,13 @@ pub extern "C" fn main() -> ! {
     let manifest = manifest::load();
     display::print_line(&format!("Manifest layers: {}", manifest.layers.len()));
 
+    display::print_line("Running ROM checksum...");
+    let mut rr = io::rom_reader::FlatRomReader;
+    match model::stream::checksum_all_layers(&mut rr, &manifest) {
+        Some(sum) => display::print_line(&format!("Checksum: 0x{:08X}", sum)),
+        None => display::print_line("Checksum failed"),
+    }
+
     // Initialize memory management system.
     let mut memory = unsafe { memory_manager::init() };
     display::print_line("Memory manager initialized");


### PR DESCRIPTION
## Summary
- add checksum_all_layers to stream each manifest layer and compute checksum
- run ROM checksum at boot to verify readable regions

## Testing
- `cargo +nightly-2022-06-21 n64 build --release` *(fails: no such subcommand `n64`)*
- `python tools/validate_weights.py` *(fails: missing weights file)*

------
https://chatgpt.com/codex/tasks/task_e_689d2316c6f48323828d84280204f9e3