### PR TITLE
Add binary manifest pipeline and ROM loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+n64llm/n64-rust/assets/weights.bin
+n64llm/n64-rust/assets/weights.manifest.bin

--- a/n64llm/assets/weights.manifest.json
+++ b/n64llm/assets/weights.manifest.json
@@ -1,5 +1,0 @@
-{
-  "version": 1,
-  "align": 64,
-  "layers": []
-}

--- a/n64llm/n64-rust/n64.ld
+++ b/n64llm/n64-rust/n64.ld
@@ -36,6 +36,13 @@ SECTIONS
     } > ROM
     __model_weights_rom_end = .;
     __model_weights_rom_size = __model_weights_rom_end - __model_weights_rom_start;
+    /* Start marker for manifest */
+    __model_manifest_rom_start = .;
+    .model_manifest ALIGN(64) :
+    {
+      KEEP(*(.model_manifest*))
+    } > ROM
+    __model_manifest_rom_end = .;
 
     /* .data: Initialized mutable data goes into RDRAM */
     .data : ALIGN(4)

--- a/n64llm/n64-rust/src/diag/manifest_check.rs
+++ b/n64llm/n64-rust/src/diag/manifest_check.rs
@@ -1,0 +1,44 @@
+use crate::{display, io::rom_reader::RomReader, weights_manifest::ManifestView};
+use crate::weights::weights_rel_to_cart_off;
+
+pub fn manifest_check<R: RomReader>(rr: &mut R, man_bytes: &'static [u8], weights_size: u64) {
+    display::print_line("=== MANIFEST CHECK ===");
+    match ManifestView::new(man_bytes) {
+        Err(_) => {
+            display::print_line("Manifest: ERR (parse)");
+            return;
+        }
+        Ok(view) => {
+            let mut ok_all = true;
+            let mut buf = [0u8; 32];
+            let mut idx: u32 = 0;
+            let _ = view.for_each(|e| {
+                let end = (e.offset as u64) + (e.size as u64);
+                let in_bounds = end <= weights_size && (e.offset as u64) % (view.align() as u64) == 0;
+                let to_read = core::cmp::min(32u32, e.size) as usize;
+                let cart_off = weights_rel_to_cart_off(e.offset as u64);
+                let ok_read = if to_read > 0 {
+                    rr.read(cart_off, &mut buf[..to_read])
+                } else {
+                    true
+                };
+                display::print_line(&format!(
+                    "[{idx:02}] {} off={} sz={}  {} {}",
+                    e.name,
+                    e.offset,
+                    e.size,
+                    if in_bounds { "BND" } else { "OOB" },
+                    if ok_read { "RD" } else { "ERR" }
+                ));
+                idx += 1;
+                ok_all &= in_bounds && ok_read;
+                true
+            });
+            if ok_all {
+                display::print_line("Manifest check: OK");
+            } else {
+                display::print_line("Manifest check: FAIL");
+            }
+        }
+    }
+}

--- a/n64llm/n64-rust/src/diag/mod.rs
+++ b/n64llm/n64-rust/src/diag/mod.rs
@@ -1,2 +1,3 @@
 pub mod rom_probe;
 pub mod weights_info;
+pub mod manifest_check;

--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -8,6 +8,7 @@ mod n64_math;
 mod n64_sys;
 mod platform;
 mod weights;
+mod weights_manifest;
 
 use alloc::format;
 use alloc::string::String;
@@ -35,6 +36,12 @@ pub extern "C" fn main() -> ! {
     let mut rr = io::rom_reader::FlatRomReader::new();
     diag::rom_probe::run_probe(&mut rr);
     diag::weights_info::show_weights_info(&mut rr);
+
+    diag::manifest_check::manifest_check(
+        &mut rr,
+        &weights_manifest::MODEL_MANIFEST,
+        weights::weights_rom_size(),
+    );
 
     let manifest = manifest::load();
     display::print_line(&format!("Manifest layers: {}", manifest.layers.len()));

--- a/n64llm/n64-rust/src/weights_manifest.rs
+++ b/n64llm/n64-rust/src/weights_manifest.rs
@@ -1,0 +1,63 @@
+#![allow(dead_code)]
+
+#[link_section = ".model_manifest"]
+#[used]
+pub static MODEL_MANIFEST: [u8; { include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"),
+    "/assets/weights.manifest.bin")).len() }] =
+    *include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/weights.manifest.bin"));
+
+#[derive(Debug, Clone, Copy)]
+pub struct Entry<'a> {
+    pub name: &'a str,
+    pub offset: u32,
+    pub size: u32,
+}
+
+pub struct ManifestView<'a> {
+    bytes: &'a [u8],
+    align: u16,
+    count: u32,
+    off_entries: usize,
+}
+
+#[derive(Debug)]
+pub enum ManErr { BadMagic, BadVersion, Truncated, Utf8 }
+
+fn rd_u16_le(b: &[u8], i: &mut usize) -> Result<u16, ManErr> {
+    if *i + 2 > b.len() { return Err(ManErr::Truncated); }
+    let v = u16::from_le_bytes([b[*i], b[*i+1]]); *i += 2; Ok(v)
+}
+fn rd_u32_le(b: &[u8], i: &mut usize) -> Result<u32, ManErr> {
+    if *i + 4 > b.len() { return Err(ManErr::Truncated); }
+    let v = u32::from_le_bytes([b[*i], b[*i+1], b[*i+2], b[*i+3]]); *i += 4; Ok(v)
+}
+
+impl<'a> ManifestView<'a> {
+    pub fn new(bytes: &'a [u8]) -> Result<Self, ManErr> {
+        let mut i = 0;
+        if bytes.len() < 12 { return Err(ManErr::Truncated); }
+        if &bytes[0..4] != b"N64W" { return Err(ManErr::BadMagic); }
+        i = 4;
+        let ver = rd_u16_le(bytes, &mut i)?;
+        if ver != 1 { return Err(ManErr::BadVersion); }
+        let align = rd_u16_le(bytes, &mut i)?;
+        let count = rd_u32_le(bytes, &mut i)?;
+        Ok(Self { bytes, align, count, off_entries: i })
+    }
+    pub fn align(&self) -> u16 { self.align }
+    pub fn count(&self) -> u32 { self.count }
+
+    pub fn for_each<F: FnMut(Entry<'a>) -> bool>(&self, mut f: F) -> Result<(), ManErr> {
+        let mut i = self.off_entries;
+        for _ in 0..self.count {
+            let nlen = rd_u16_le(self.bytes, &mut i)? as usize;
+            if i + nlen + 8 > self.bytes.len() { return Err(ManErr::Truncated); }
+            let name_bytes = &self.bytes[i..i+nlen]; i += nlen;
+            let off = u32::from_le_bytes(self.bytes[i..i+4].try_into().unwrap()); i += 4;
+            let sz  = u32::from_le_bytes(self.bytes[i..i+4].try_into().unwrap()); i += 4;
+            let name = core::str::from_utf8(name_bytes).map_err(|_| ManErr::Utf8)?;
+            if !f(Entry { name, offset: off, size: sz }) { break; }
+        }
+        Ok(())
+    }
+}

--- a/tools/spec.json
+++ b/tools/spec.json
@@ -1,0 +1,7 @@
+{
+  "layers": [
+    {"name": "tok_embeddings", "path": "tools/dummy/tok_emb.bin"},
+    {"name": "attn_q_0", "path": "tools/dummy/l0_q.bin"},
+    {"name": "attn_k_0", "path": "tools/dummy/l0_k.bin"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add Python exporter that concatenates model weight files and emits a binary manifest with 64‑byte alignment
- provide validator script and sample spec for manifest generation
- embed manifest in a new `.model_manifest` linker section with zero‑alloc loader and diagnostics

## Testing
- `python3 tools/export_model.py --spec tools/spec.json --out-bin n64llm/n64-rust/assets/weights.bin --out-man n64llm/n64-rust/assets/weights.manifest.bin`
- `python3 tools/validate_weights.py --bin n64llm/n64-rust/assets/weights.bin --man n64llm/n64-rust/assets/weights.manifest.bin`

------
https://chatgpt.com/codex/tasks/task_e_689d323ffed08323a0e2bea23d38df08