### PR TITLE
Add streaming bench with double buffering and timers

### DIFF
--- a/n64llm/n64-rust/src/config.rs
+++ b/n64llm/n64-rust/src/config.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-pub const BURST_BYTES: usize = 32 * 1024; // Try 16K, 32K, 64K
+pub const BURST_BYTES: usize = 32 * 1024; // Try 16K/32K/64K later
 pub const ROM_ALIGN: usize = 64;          // Exporter enforces; reader asserts
+pub const BENCH_MAX_BYTES_PER_ENTRY: u32 = 4 * 1024 * 1024; // cap per entry for quick bench
 pub const PROBE_OFFSETS: &[u64] = &[
     16 * 1024 * 1024,    // 16 MiB
     128 * 1024 * 1024,   // 128 MiB

--- a/n64llm/n64-rust/src/diag/mod.rs
+++ b/n64llm/n64-rust/src/diag/mod.rs
@@ -1,3 +1,4 @@
 pub mod rom_probe;
 pub mod weights_info;
 pub mod manifest_check;
+pub mod stream_bench;

--- a/n64llm/n64-rust/src/diag/stream_bench.rs
+++ b/n64llm/n64-rust/src/diag/stream_bench.rs
@@ -1,0 +1,64 @@
+use crate::weights_manifest::ManifestView;
+use crate::weights::{weights_rom_size, weights_rel_to_cart_off};
+use crate::io::rom_reader::RomReader;
+use crate::stream::streamer::stream_entry;
+use crate::display;
+use crate::config::BENCH_MAX_BYTES_PER_ENTRY;
+use crate::util::adler32;
+
+pub fn run<R: RomReader>(rr: &mut R, man_bytes: &'static [u8]) {
+    display::print_line("=== STREAM BENCH ===");
+    let total_weights = weights_rom_size();
+
+    let view = match ManifestView::new(man_bytes) {
+        Ok(v) => v,
+        Err(_) => { display::print_line("Manifest parse ERR"); return; }
+    };
+
+    let mut idx = 0u32;
+    let _ = view.for_each(|e| {
+        let mut to_read = e.size as u64;
+        if BENCH_MAX_BYTES_PER_ENTRY > 0 {
+            to_read = core::cmp::min(to_read, BENCH_MAX_BYTES_PER_ENTRY as u64);
+        }
+        let end = (e.offset as u64).saturating_add(to_read);
+        let in_bounds = end <= total_weights;
+
+        // Adler32 over streamed data (as stand-in for compute)
+        let mut s1: u32 = 1; let mut s2: u32 = 0;
+        let cart_off = weights_rel_to_cart_off(e.offset as u64);
+
+        let stats = if in_bounds {
+            stream_entry(rr, cart_off, to_read, |chunk| {
+                (s1, s2) = adler32::adler32(s1, s2, chunk);
+            })
+        } else { None };
+
+        match stats {
+            None => display::print_line(&format!("[{idx:02}] {}  FAIL", e.name)),
+            Some(st) => {
+                let kbps = if st.dma_us > 0 {
+                    // KiB/s = bytes / us * 1e6 / 1024
+                    ((st.bytes as u128) * 1_000_000u128 / (st.dma_us as u128) / 1024u128) as u64
+                } else { 0 };
+                let dma_pct = if (st.dma_us + st.compute_us) > 0 {
+                    (st.dma_us * 100) / (st.dma_us + st.compute_us)
+                } else { 0 };
+                display::print_line(&format!(
+                    "[{idx:02}] {:16} rd={} KiB  bursts={}  DMA={}ms  CMP={}ms  BW={} KiB/s  DMA%={}  A32={:08X}:{:08X}",
+                    e.name,
+                    st.bytes / 1024,
+                    st.bursts,
+                    st.dma_us / 1000,
+                    st.compute_us / 1000,
+                    kbps,
+                    dma_pct,
+                    s1, s2
+                ));
+            }
+        }
+        idx += 1;
+        true
+    });
+}
+

--- a/n64llm/n64-rust/src/io/dbuf.rs
+++ b/n64llm/n64-rust/src/io/dbuf.rs
@@ -1,25 +1,15 @@
 pub struct Dbuf<const N: usize> {
-    a: [u8; N],
-    b: [u8; N],
-    use_a: bool,
+    cur: [u8; N],
+    nxt: [u8; N],
 }
 
 impl<const N: usize> Dbuf<N> {
-    pub const fn new() -> Self {
-        Self {
-            a: [0; N],
-            b: [0; N],
-            use_a: true,
-        }
-    }
-
-    pub fn pair(&mut self) -> (&mut [u8; N], &mut [u8; N]) {
-        if self.use_a {
-            self.use_a = false;
-            (&mut self.a, &mut self.b)
-        } else {
-            self.use_a = true;
-            (&mut self.b, &mut self.a)
-        }
-    }
+    pub const fn new() -> Self { Self { cur: [0; N], nxt: [0; N] } }
+    #[inline(always)]
+    pub fn cur_mut(&mut self) -> &mut [u8; N] { &mut self.cur }
+    #[inline(always)]
+    pub fn nxt_mut(&mut self) -> &mut [u8; N] { &mut self.nxt }
+    #[inline(always)]
+    pub fn swap(&mut self) { core::mem::swap(&mut self.cur, &mut self.nxt); }
 }
+

--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -23,6 +23,8 @@ mod manifest;
 mod memory_manager;
 mod model;
 mod tokenizer;
+mod util;
+mod stream;
 
 #[no_mangle]
 pub extern "C" fn main() -> ! {
@@ -42,6 +44,9 @@ pub extern "C" fn main() -> ! {
         &weights_manifest::MODEL_MANIFEST,
         weights::weights_rom_size(),
     );
+
+    diag::stream_bench::run(&mut rr, &crate::weights_manifest::MODEL_MANIFEST);
+    wait_for_start_button();
 
     let manifest = manifest::load();
     display::print_line(&format!("Manifest layers: {}", manifest.layers.len()));
@@ -107,6 +112,10 @@ pub extern "C" fn main() -> ! {
 
         delay(1000);
     }
+}
+
+fn wait_for_start_button() {
+    // Controller polling not implemented; placeholder for hardware pause.
 }
 
 fn delay(ms: u32) {

--- a/n64llm/n64-rust/src/platform/mod.rs
+++ b/n64llm/n64-rust/src/platform/mod.rs
@@ -1,2 +1,3 @@
 pub mod pi;
+pub mod time;
 

--- a/n64llm/n64-rust/src/platform/time.rs
+++ b/n64llm/n64-rust/src/platform/time.rs
@@ -1,0 +1,27 @@
+// CP0 Count increments at ~CPU/2. Common N64 value ~46_875_000 Hz (93.75 MHz / 2).
+// Adjust COUNT_HZ if your environment differs.
+pub const COUNT_HZ: u64 = 46_875_000;
+
+#[inline(always)]
+pub fn now_cycles() -> u64 {
+    let v: u32;
+    unsafe { core::arch::asm!("mfc0 {0}, $9", out(reg) v) };
+    v as u64 // 32-bit; fine for short intervals
+}
+
+#[inline(always)]
+pub fn cycles_to_us(cycles: u64) -> u64 {
+    (cycles * 1_000_000) / COUNT_HZ
+}
+
+pub struct Stopwatch { start: u64, acc: u64 }
+
+impl Stopwatch {
+    pub fn new() -> Self { Self { start: 0, acc: 0 } }
+    pub fn start(&mut self) { self.start = now_cycles(); }
+    pub fn stop_add(&mut self) { self.acc += now_cycles().saturating_sub(self.start); }
+    pub fn cycles(&self) -> u64 { self.acc }
+    pub fn micros(&self) -> u64 { cycles_to_us(self.acc) }
+    pub fn reset(&mut self) { self.acc = 0; }
+}
+

--- a/n64llm/n64-rust/src/stream/mod.rs
+++ b/n64llm/n64-rust/src/stream/mod.rs
@@ -1,0 +1,2 @@
+pub mod streamer;
+

--- a/n64llm/n64-rust/src/stream/streamer.rs
+++ b/n64llm/n64-rust/src/stream/streamer.rs
@@ -1,0 +1,80 @@
+use crate::io::rom_reader::RomReader;
+use crate::io::dbuf::Dbuf;
+use crate::platform::time::Stopwatch;
+use crate::config::{BURST_BYTES, ROM_ALIGN};
+
+pub struct StreamStats {
+    pub bytes: u64,
+    pub bursts: u32,
+    pub dma_us: u64,
+    pub compute_us: u64,
+}
+
+pub fn stream_entry<R, F>(
+    rr: &mut R,
+    entry_offset: u64,  // weights-relative
+    entry_size: u64,
+    mut on_chunk: F,     // compute callback: fn(&[u8])
+) -> Option<StreamStats>
+where
+    R: RomReader,
+    F: FnMut(&[u8]),
+{
+    if BURST_BYTES == 0 { return None; }
+
+    let mut stats = StreamStats { bytes: 0, bursts: 0, dma_us: 0, compute_us: 0 };
+    let mut remain = entry_size;
+    let mut off    = entry_offset;
+
+    let mut dbuf: Dbuf<{ BURST_BYTES }> = Dbuf::new();
+    let mut dma_sw = Stopwatch::new();
+    let mut cmp_sw = Stopwatch::new();
+
+    // Helper: read exactly `len` bytes into buf[0..len]
+    let mut read_burst = |rom_off: u64, buf: &mut [u8], len: usize| -> bool {
+        // Enforce minimum alignment at the start; head/tail alignment handled in pi layer if needed.
+        debug_assert!(rom_off % (ROM_ALIGN as u64) == 0 || len < ROM_ALIGN);
+        dma_sw.start();
+        let ok = rr.read(rom_off, &mut buf[..len]);
+        dma_sw.stop_add();
+        ok
+    };
+
+    // Prime first buffer
+    let mut first = core::cmp::min(BURST_BYTES as u64, remain) as usize;
+    if first == 0 { return Some(stats); }
+    if !read_burst(off, dbuf.cur_mut(), first) { return None; }
+    off += first as u64;
+    remain -= first as u64;
+
+    while remain > 0 {
+        let next_len = core::cmp::min(BURST_BYTES as u64, remain) as usize;
+        // Start next DMA into nxt
+        if !read_burst(off, dbuf.nxt_mut(), next_len) { return None; }
+
+        // Compute on current
+        cmp_sw.start();
+        on_chunk(&dbuf.cur_mut()[..first]);
+        cmp_sw.stop_add();
+
+        // Bookkeeping & swap
+        stats.bytes += first as u64;
+        stats.bursts += 1;
+        dbuf.swap();
+        first = next_len;
+        off += next_len as u64;
+        remain -= next_len as u64;
+    }
+
+    // Drain last
+    cmp_sw.start();
+    on_chunk(&dbuf.cur_mut()[..first]);
+    cmp_sw.stop_add();
+    stats.bytes += first as u64;
+    stats.bursts += 1;
+
+    stats.dma_us = dma_sw.micros();
+    stats.compute_us = cmp_sw.micros();
+    Some(stats)
+}
+

--- a/n64llm/n64-rust/src/util/adler32.rs
+++ b/n64llm/n64-rust/src/util/adler32.rs
@@ -1,0 +1,9 @@
+pub fn adler32(mut s1: u32, mut s2: u32, data: &[u8]) -> (u32, u32) {
+    const MOD: u32 = 65521;
+    for &b in data {
+        s1 = (s1 + b as u32) % MOD;
+        s2 = (s2 + s1) % MOD;
+    }
+    (s1, s2)
+}
+

--- a/n64llm/n64-rust/src/util/mod.rs
+++ b/n64llm/n64-rust/src/util/mod.rs
@@ -1,0 +1,2 @@
+pub mod adler32;
+


### PR DESCRIPTION
## Summary
- add CP0-based stopwatch utilities
- implement double-buffered ROM streaming helper with stats
- benchmark manifest entries with checksum placeholder

## Testing
- `cargo check` *(fails: argument never used; missing manifest assets)*

------
https://chatgpt.com/codex/tasks/task_e_689d3498a8108323b830799ae7453902