### PR TITLE
Implement manifest-driven single-token decode demo

### DIFF
--- a/n64llm/n64-rust/src/diag/decode_once.rs
+++ b/n64llm/n64-rust/src/diag/decode_once.rs
@@ -1,0 +1,35 @@
+use crate::{io::rom_reader::RomReader, display};
+use crate::weights_manifest::ManifestView;
+use crate::model::{dims::ModelDims};
+use crate::model::config::{D_MODEL_FALLBACK, VOCAB_FALLBACK};
+use crate::model::meta::load_dims_from_meta;
+use crate::infer::{embedding::gather_embedding, decoder::argmax_over_head};
+use alloc::format;
+use alloc::vec;
+
+pub fn run<R: RomReader>(rr: &mut R, man_bytes: &'static [u8], seed_token: u32) {
+    display::print_line("=== DECODE ONCE ===");
+
+    let man = match ManifestView::new(man_bytes) {
+        Ok(v) => v, Err(_) => { display::print_line("Manifest parse ERR"); return; }
+    };
+
+    let dims = load_dims_from_meta(rr, &man)
+        .unwrap_or_else(|| ModelDims::new(D_MODEL_FALLBACK, VOCAB_FALLBACK));
+    display::print_line(&format!("dims: d_model={} vocab={}", dims.d_model, dims.vocab_size));
+
+    let mut h = vec![0.0f32; dims.d_model as usize];
+    let mut row = vec![0u8; (dims.d_model as usize) * 4];
+
+    if !gather_embedding(rr, &man, &dims, seed_token, &mut h) {
+        display::print_line("Embedding: FAIL");
+        return;
+    }
+
+    match argmax_over_head(rr, &man, &dims, &h, &mut row) {
+        None => display::print_line("Decoder: FAIL"),
+        Some(st) => {
+            display::print_line(&format!("next_token={}  logit={:.3}  scanned={}", st.best_id, st.best_logit, st.scanned));
+        }
+    }
+}

--- a/n64llm/n64-rust/src/diag/mod.rs
+++ b/n64llm/n64-rust/src/diag/mod.rs
@@ -2,3 +2,4 @@ pub mod rom_probe;
 pub mod weights_info;
 pub mod manifest_check;
 pub mod stream_bench;
+pub mod decode_once;

--- a/n64llm/n64-rust/src/infer/decoder.rs
+++ b/n64llm/n64-rust/src/infer/decoder.rs
@@ -1,0 +1,52 @@
+use crate::{io::rom_reader::RomReader, weights_manifest::ManifestView};
+use crate::weights_manifest_find::find;
+use crate::weights::weights_rel_to_cart_off;
+use crate::config::BURST_BYTES;
+use crate::util::f32le::dot_f32le_row;
+use crate::model::dims::ModelDims;
+
+pub struct DecodeStats {
+    pub best_id: u32,
+    pub best_logit: f32,
+    pub scanned: u32,
+}
+
+pub fn argmax_over_head<R: RomReader>(
+    rr: &mut R,
+    man: &ManifestView<'_>,
+    dims: &ModelDims,
+    h: &[f32],                // len = d_model
+    scratch_row: &mut [u8],   // len >= d_model*4
+) -> Option<DecodeStats> {
+    let e = find(man, crate::model::names::L_LM_HEAD)?;
+    let d_model = dims.d_model as usize;
+    let vocab   = dims.vocab_size as usize;
+
+    if h.len() < d_model || scratch_row.len() < d_model*4 { return None; }
+
+    let row_bytes = (d_model * 4) as u64;
+    if (row_bytes * vocab as u64) > e.size as u64 { return None; }
+
+    let mut best_id: u32 = 0;
+    let mut best_logit = f32::NEG_INFINITY;
+    let mut scanned: u32 = 0;
+
+    for i in 0..vocab {
+        let off_rel = (i as u64) * row_bytes;
+        let cart_off = weights_rel_to_cart_off(e.offset as u64 + off_rel);
+
+        let to_read = d_model * 4;
+        if !rr.read(cart_off, &mut scratch_row[..to_read]) { return None; }
+
+        let logit = dot_f32le_row(&scratch_row[..to_read], h);
+        if logit > best_logit {
+            best_logit = logit;
+            best_id = i as u32;
+        }
+        scanned += 1;
+
+        if (i % (BURST_BYTES / 64).max(1)) == 0 {
+        }
+    }
+    Some(DecodeStats { best_id, best_logit, scanned })
+}

--- a/n64llm/n64-rust/src/infer/embedding.rs
+++ b/n64llm/n64-rust/src/infer/embedding.rs
@@ -1,0 +1,30 @@
+use crate::{io::rom_reader::RomReader, weights_manifest::ManifestView};
+use crate::weights_manifest_find::find;
+use crate::weights::weights_rel_to_cart_off;
+use crate::util::f32le::load_f32le_slice;
+use crate::model::dims::ModelDims;
+use alloc::vec;
+
+pub fn gather_embedding<R: RomReader>(
+    rr: &mut R,
+    man: &ManifestView<'_>,
+    dims: &ModelDims,
+    token_id: u32,
+    out_h: &mut [f32],              // len = d_model
+) -> bool {
+    let e = match find(man, crate::model::names::L_TOK_EMB) { Some(v) => v, None => return false };
+    let d_model = dims.d_model as usize;
+    if out_h.len() < d_model { return false; }
+
+    // row offset in bytes: token_id * d_model * 4
+    let row_bytes = (d_model * 4) as u64;
+    let off_rel   = (token_id as u64) * row_bytes;
+    if off_rel + row_bytes > e.size as u64 { return false; }
+
+    let mut buf = vec![0u8; d_model * 4];
+    let cart_off = weights_rel_to_cart_off(e.offset as u64 + off_rel);
+    if !rr.read(cart_off, &mut buf) { return false; }
+
+    load_f32le_slice(out_h, &buf);
+    true
+}

--- a/n64llm/n64-rust/src/infer/mod.rs
+++ b/n64llm/n64-rust/src/infer/mod.rs
@@ -1,0 +1,2 @@
+pub mod embedding;
+pub mod decoder;

--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -9,6 +9,7 @@ mod n64_sys;
 mod platform;
 mod weights;
 mod weights_manifest;
+mod weights_manifest_find;
 
 use alloc::format;
 use alloc::string::String;
@@ -24,6 +25,7 @@ mod memory_manager;
 mod model;
 mod tokenizer;
 mod util;
+mod infer;
 mod stream;
 
 #[no_mangle]
@@ -46,6 +48,7 @@ pub extern "C" fn main() -> ! {
     );
 
     diag::stream_bench::run(&mut rr, &crate::weights_manifest::MODEL_MANIFEST);
+    diag::decode_once::run(&mut rr, &crate::weights_manifest::MODEL_MANIFEST, 42);
     wait_for_start_button();
 
     let manifest = manifest::load();

--- a/n64llm/n64-rust/src/model/config.rs
+++ b/n64llm/n64-rust/src/model/config.rs
@@ -1,0 +1,2 @@
+pub const D_MODEL_FALLBACK: u32 = 512;
+pub const VOCAB_FALLBACK:  u32 = 2048;

--- a/n64llm/n64-rust/src/model/dims.rs
+++ b/n64llm/n64-rust/src/model/dims.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Copy, Clone)]
+pub struct ModelDims { pub d_model: u32, pub vocab_size: u32 }
+
+impl ModelDims {
+    pub const fn new(d_model: u32, vocab_size: u32) -> Self { Self { d_model, vocab_size } }
+}

--- a/n64llm/n64-rust/src/model/infer_dims.rs
+++ b/n64llm/n64-rust/src/model/infer_dims.rs
@@ -1,0 +1,10 @@
+use crate::{model::dims::ModelDims, weights_manifest::ManifestView};
+use crate::weights_manifest_find::find;
+
+pub fn infer_from_layers(man: &ManifestView<'_>) -> Option<ModelDims> {
+    let _e_emb  = find(man, crate::model::names::L_TOK_EMB)?;
+    let _e_head = find(man, crate::model::names::L_LM_HEAD)?;
+    // Both are vocab*d_model*4 (f32 LE). We can’t get vocab and d_model uniquely from sizes alone.
+    // For now, assume they’re equal and we rely on a known vocab, or we provide META soon.
+    None
+}

--- a/n64llm/n64-rust/src/model/meta.rs
+++ b/n64llm/n64-rust/src/model/meta.rs
@@ -1,0 +1,17 @@
+use crate::{model::dims::ModelDims, weights_manifest::ManifestView};
+use crate::weights_manifest_find::find;
+use crate::weights::weights_rel_to_cart_off;
+use crate::io::rom_reader::RomReader;
+
+pub fn load_dims_from_meta<R: RomReader>(rr: &mut R, man: &ManifestView<'_>) -> Option<ModelDims> {
+    let e = find(man, crate::model::names::L_MODEL_META)?;
+    if e.size < 12 { return None; }
+    let mut buf = [0u8; 12];
+    let ok = rr.read(weights_rel_to_cart_off(e.offset as u64), &mut buf);
+    if !ok { return None; }
+    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+    if magic != 0x4D455441 { return None; } // 'META'
+    let d_model = u32::from_le_bytes(buf[4..8].try_into().unwrap());
+    let vocab   = u32::from_le_bytes(buf[8..12].try_into().unwrap());
+    Some(ModelDims::new(d_model, vocab))
+}

--- a/n64llm/n64-rust/src/model/mod.rs
+++ b/n64llm/n64-rust/src/model/mod.rs
@@ -1,1 +1,6 @@
+pub mod names;
+pub mod dims;
+pub mod meta;
+pub mod config;
+pub mod infer_dims;
 pub mod stream;

--- a/n64llm/n64-rust/src/model/names.rs
+++ b/n64llm/n64-rust/src/model/names.rs
@@ -1,0 +1,3 @@
+pub const L_TOK_EMB: &str = "tok_embeddings";   // row-major [vocab, d_model], f32 LE
+pub const L_LM_HEAD: &str = "lm_head";          // row-major [vocab, d_model], f32 LE (no bias)
+pub const L_MODEL_META: &str = "model_meta";    // optional: small binary meta

--- a/n64llm/n64-rust/src/util/f32le.rs
+++ b/n64llm/n64-rust/src/util/f32le.rs
@@ -1,0 +1,22 @@
+#[inline(always)]
+pub fn dot_f32le_row(row_le: &[u8], x: &[f32]) -> f32 {
+    let mut acc = 0.0f32;
+    let mut i = 0;
+    for xi in x {
+        let u = u32::from_le_bytes([row_le[i], row_le[i+1], row_le[i+2], row_le[i+3]]);
+        let wi = f32::from_bits(u);
+        acc = acc + wi * *xi;
+        i += 4;
+    }
+    acc
+}
+
+#[inline(always)]
+pub fn load_f32le_slice(dst: &mut [f32], src_le: &[u8]) {
+    let mut j = 0;
+    for d in dst.iter_mut() {
+        let u = u32::from_le_bytes([src_le[j], src_le[j+1], src_le[j+2], src_le[j+3]]);
+        *d = f32::from_bits(u);
+        j += 4;
+    }
+}

--- a/n64llm/n64-rust/src/util/mod.rs
+++ b/n64llm/n64-rust/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod adler32;
+pub mod f32le;
 

--- a/n64llm/n64-rust/src/weights_manifest_find.rs
+++ b/n64llm/n64-rust/src/weights_manifest_find.rs
@@ -1,0 +1,8 @@
+use crate::weights_manifest::{ManifestView, Entry};
+
+pub fn find<'a>(view: &'a ManifestView<'a>, name: &str) -> Option<Entry<'a>> {
+    let mut found: Option<Entry<'a>> = None;
+    let _ = view.for_each(|e| { if e.name == name { found = Some(e); false } else { true } });
+    found
+}
+


### PR DESCRIPTION
## Summary
- add layer name constants, dimension structs, and meta reader
- implement little-endian f32 helpers and streamed embedding/decoder logic
- wire up a `decode_once` diagnostic that gathers an embedding and finds the next token

## Testing
- `cargo check` *(fails: duplicate panic implementation and missing assets)*

------
https://chatgpt.com/codex/tasks/task_e_689d7a1ade3c83239b1701e0269b381f