### PR TITLE
Implement PI DMA read and extend ROM capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ ROM size produced by the project.
 
 ## Exporting model weights
 
-Model weights live in `n64llm/assets/weights.bin` with layout described by
-`weights.manifest.json`. The helper script `tools/export_model.py` can combine
+Model weights live in `n64llm/n64-rust/assets/weights.bin` with layout described by
+`weights.manifest.bin`. The helper script `tools/export_model.py` can combine
 individual layer files into these artifacts:
 
 ```bash
@@ -95,11 +95,12 @@ Before running on real hardware you can verify that the bundled weight blob
 matches its manifest. Run the helper script from the repository root:
 
 ```bash
-python tools/validate_weights.py
+python tools/validate_weights.py --bin n64llm/n64-rust/assets/weights.bin \
+  --man n64llm/n64-rust/assets/weights.manifest.bin
 ```
 
-The script checks that `n64llm/assets/weights.bin` exists, that each layer in
-`weights.manifest.json` is 64-byte aligned, and that the sizes sum to the file
+The script checks that `n64llm/n64-rust/assets/weights.bin` exists, that each layer in
+`weights.manifest.bin` is 64-byte aligned, and that the sizes sum to the file
 length.
 
 ### Git hook for automatic validation
@@ -112,5 +113,5 @@ git config core.hooksPath .githooks
 ```
 
 With the hook active, any commit that modifies
-`n64llm/assets/weights.bin` will automatically invoke
+`n64llm/n64-rust/assets/weights.bin` will automatically invoke
 `tools/validate_weights.py` and abort the commit if validation fails.

--- a/n64llm/n64-rust/src/config.rs
+++ b/n64llm/n64-rust/src/config.rs
@@ -4,15 +4,17 @@ pub const BURST_BYTES: usize = 32 * 1024; // Try 16K/32K/64K later
 pub const ROM_ALIGN: usize = 64;          // Exporter enforces; reader asserts
 pub const BENCH_MAX_BYTES_PER_ENTRY: u32 = 4 * 1024 * 1024; // cap per entry for quick bench
 pub const PROBE_OFFSETS: &[u64] = &[
-    16 * 1024 * 1024,    // 16 MiB
+    16  * 1024 * 1024,   // 16 MiB (sanity)
     128 * 1024 * 1024,   // 128 MiB
     256 * 1024 * 1024,   // 256 MiB
-    400 * 1024 * 1024,   // 400 MiB (below your ~500 MB)
-    480 * 1024 * 1024,   // 480 MiB (push the edge)
+    512 * 1024 * 1024,   // 512 MiB
+    768 * 1024 * 1024,   // 768 MiB
+    960 * 1024 * 1024,   // 960 MiB
+    1023 * 1024 * 1024,  // near 1 GiB end
 ];
 
 pub const PROBE_SAMPLE_BYTES: usize = 64;     // small, quick sanity read
 pub const ENABLE_DOUBLE_BUFFER: bool = true;
 pub const UI_BURSTS_PER_REFRESH: usize = 4;
 // Maximum ROM bytes to treat as readable (e.g., firmware cap)
-pub const ROM_LIMIT_BYTES: u64 = 480 * 1024 * 1024;
+pub const ROM_LIMIT_BYTES: u64 = 1024 * 1024 * 1024;

--- a/n64llm/n64-rust/src/model/stream.rs
+++ b/n64llm/n64-rust/src/model/stream.rs
@@ -2,7 +2,7 @@ use crate::{
     config,
     io::{dbuf::Dbuf, rom_reader::RomReader},
     manifest::Manifest,
-    weights::{weights_rom_base, weights_rom_size},
+    weights::{weights_rel_to_cart_off, weights_rom_size},
 };
 
 /// Streams a model layer from ROM using a [`RomReader`] and double buffering.
@@ -25,7 +25,8 @@ where
     if layer.offset as usize + layer.size as usize > weights_rom_size() {
         return false;
     }
-    let mut off = layer.offset as u64 + weights_rom_base() as u64;
+    // RomReader expects cart-relative offsets.
+    let mut off = weights_rel_to_cart_off(layer.offset as u64);
     let mut remain = layer.size as u64;
 
     const BURST: usize = config::BURST_BYTES;

--- a/n64llm/n64-rust/src/platform/pi.rs
+++ b/n64llm/n64-rust/src/platform/pi.rs
@@ -1,8 +1,5 @@
-use core::ptr::{read_volatile, write_volatile, copy_nonoverlapping};
-use crate::n64_sys::{
-    PI_DRAM_ADDR_REG, PI_CART_ADDR_REG, PI_RD_LEN_REG, PI_STATUS_REG,
-    PI_STATUS_DMA_BUSY,
-};
+use crate::config::{BURST_BYTES, ROM_LIMIT_BYTES};
+use crate::n64_sys::pi_read;
 
 pub const CART_BASE: u64 = 0x1000_0000; // N64 cart PI bus base
 
@@ -13,63 +10,26 @@ pub enum PiError {
     Oob,
 }
 
-#[inline(always)]
-fn pi_busy() -> bool {
-    unsafe { (read_volatile(PI_STATUS_REG as *const u32) & PI_STATUS_DMA_BUSY) != 0 }
-}
-
-/// Blocking PI DMA read of len = dst.len() bytes from cart-space offset.
-/// Splits into bursts and handles misalignment with a scratch buffer.
+/// Uses low-level PI to DMA chunks directly into RDRAM.
 pub fn pi_dma_read(rom_abs_off: u64, dst: &mut [u8]) -> Result<(), PiError> {
-    if dst.is_empty() { return Ok(()); }
-
-    let mut cart = (CART_BASE + rom_abs_off) as u32;
-    let mut rem = dst.len();
-    let mut p = dst.as_mut_ptr();
-
-    const BURST_MAX: usize = 32 * 1024;
-    const ALIGN: usize = 64;
-    static mut SCRATCH: [u8; ALIGN] = [0; ALIGN];
-
-    unsafe {
-        // Head misalignment
-        let head_off = (cart as usize) & (ALIGN - 1);
-        if head_off != 0 {
-            let read_addr = cart - head_off as u32;
-            while pi_busy() {}
-            write_volatile(PI_DRAM_ADDR_REG as *mut u32, SCRATCH.as_mut_ptr() as u32);
-            write_volatile(PI_CART_ADDR_REG as *mut u32, read_addr);
-            write_volatile(PI_RD_LEN_REG as *mut u32, (ALIGN as u32) - 1);
-            while pi_busy() {}
-            let copy_sz = core::cmp::min(ALIGN - head_off, rem);
-            copy_nonoverlapping(SCRATCH.as_ptr().add(head_off), p, copy_sz);
-            p = p.add(copy_sz);
-            cart = cart.wrapping_add(copy_sz as u32);
-            rem -= copy_sz;
-        }
-
-        // Aligned bursts
-        while rem >= ALIGN {
-            let sz = core::cmp::min(rem & !(ALIGN - 1), BURST_MAX);
-            while pi_busy() {}
-            write_volatile(PI_DRAM_ADDR_REG as *mut u32, p as u32);
-            write_volatile(PI_CART_ADDR_REG as *mut u32, cart);
-            write_volatile(PI_RD_LEN_REG as *mut u32, (sz as u32) - 1);
-            while pi_busy() {}
-            p = p.add(sz);
-            cart = cart.wrapping_add(sz as u32);
-            rem -= sz;
-        }
-
-        // Tail
-        if rem > 0 {
-            while pi_busy() {}
-            write_volatile(PI_DRAM_ADDR_REG as *mut u32, SCRATCH.as_mut_ptr() as u32);
-            write_volatile(PI_CART_ADDR_REG as *mut u32, cart);
-            write_volatile(PI_RD_LEN_REG as *mut u32, (ALIGN as u32) - 1);
-            while pi_busy() {}
-            copy_nonoverlapping(SCRATCH.as_ptr(), p, rem);
-        }
+    // Reject ranges beyond configured ROM window.
+    let end = rom_abs_off
+        .checked_add(dst.len() as u64)
+        .ok_or(PiError::Oob)?;
+    if end > ROM_LIMIT_BYTES {
+        return Err(PiError::Oob);
     }
+
+    // Transfer in bursts; pi_read waits for DMA completion internally.
+    let mut done = 0usize;
+    while done < dst.len() {
+        let chunk = core::cmp::min(dst.len() - done, BURST_BYTES);
+        let rom_addr = (CART_BASE + rom_abs_off + done as u64) as u32;
+        unsafe {
+            pi_read(dst.as_mut_ptr().add(done), rom_addr, chunk as u32);
+        }
+        done += chunk;
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
- implement PI DMA reader using `pi_read` with bounds checking
- stream layers with cart-relative offsets via `weights_rel_to_cart_off`
- expand ROM probe/limit to 1 GiB and refresh README for binary manifest

## Testing
- `cargo check` *(fails: couldn't read assets/weights.bin and manifest)*

------
https://chatgpt.com/codex/tasks/task_e_689f735a35388323910231480ad6161a