### PR TITLE
Add async PI DMA and streaming prefetcher

### DIFF
--- a/n64llm/n64-rust/src/config.rs
+++ b/n64llm/n64-rust/src/config.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code)]
 
 pub const BURST_BYTES: usize = 32 * 1024; // Try 16K/32K/64K later
+
+// Size of each streaming block (x2 for double-buffer). Keep modest for 8 MiB RDRAM.
+pub const STREAM_BLOCK_BYTES: usize = 32 * 1024;
 pub const ROM_ALIGN: usize = 64;          // Exporter enforces; reader asserts
 pub const BENCH_MAX_BYTES_PER_ENTRY: u32 = 4 * 1024 * 1024; // cap per entry for quick bench
 pub const PROBE_OFFSETS: &[u64] = &[

--- a/n64llm/n64-rust/src/model/stream.rs
+++ b/n64llm/n64-rust/src/model/stream.rs
@@ -1,71 +1,48 @@
-use crate::{
-    config,
-    io::{dbuf::Dbuf, rom_reader::RomReader},
-    manifest::Manifest,
-    weights::{weights_rel_to_cart_off, weights_rom_size},
-};
+use crate::platform::cart::RomSource;
+use crate::stream::prefetch::Prefetcher;
+use crate::manifest::Manifest;
 
-/// Streams a model layer from ROM using a [`RomReader`] and double buffering.
-/// Calls `on_chunk` for each chunk of data read.
-/// Returns `false` on any read error.
-pub fn stream_layer<R: RomReader, F>(
-    rr: &mut R,
-    manifest: &Manifest,
-    layer_idx: usize,
-    mut on_chunk: F,
-) -> bool
-where
-    F: FnMut(&[u8]),
-{
-    if layer_idx >= manifest.layers.len() {
-        return false;
-    }
-
-    let layer = &manifest.layers[layer_idx];
-    if layer.offset as usize + layer.size as usize > weights_rom_size() {
-        return false;
-    }
-    // RomReader expects cart-relative offsets.
-    let mut off = weights_rel_to_cart_off(layer.offset as u64);
-    let mut remain = layer.size as u64;
-
-    const BURST: usize = config::BURST_BYTES;
-    let mut dbuf: Dbuf<BURST> = Dbuf::new();
-
-    let mut first = core::cmp::min(remain as usize, BURST);
-    if !rr.read(off, &mut dbuf.cur_mut()[..first]) {
-        return false;
-    }
-    off += first as u64;
-    remain -= first as u64;
-
-    while remain > 0 {
-        let to_read = core::cmp::min(remain as usize, BURST);
-        if !rr.read(off, &mut dbuf.nxt_mut()[..to_read]) {
-            return false;
-        }
-        on_chunk(&dbuf.cur_mut()[..first]);
-        dbuf.swap();
-        first = to_read;
-        off += to_read as u64;
-        remain -= to_read as u64;
-    }
-
-    on_chunk(&dbuf.cur_mut()[..first]);
-    true
+pub struct LayerDesc {
+    pub offset: u32,
+    pub len: u32,
 }
 
-/// Streams all layers listed in `manifest` and computes a simple rolling
-/// checksum. Returns `Some(crc)` on success or `None` if any read fails.
-pub fn checksum_all_layers<R: RomReader>(rr: &mut R, manifest: &Manifest) -> Option<u32> {
+pub enum StreamError {
+    Io,
+}
+
+pub fn stream_layer<R: RomSource>(
+    rom: R,
+    layer: &LayerDesc,
+    mut consume: impl FnMut(&[u8]) -> (),
+    mut on_progress: impl FnMut(u64, u64) -> (),
+) -> Result<(), StreamError> {
+    // Static 2×32 KiB (tweak in config if you like).
+    static mut A: [u8; crate::config::STREAM_BLOCK_BYTES] = [0; crate::config::STREAM_BLOCK_BYTES];
+    static mut B: [u8; crate::config::STREAM_BLOCK_BYTES] = [0; crate::config::STREAM_BLOCK_BYTES];
+    let pre = unsafe { Prefetcher::new(rom, layer.offset as u64, layer.len as u64, &mut A, &mut B) };
+    let mut pf = pre;
+    let total = layer.len as u64;
+    while let Some(chunk) = pf.next_block() {
+        consume(chunk);
+        let done = total - pf.remaining();
+        on_progress(done, total);
+    }
+    Ok(())
+}
+
+pub fn checksum_all_layers<R: RomSource + Copy>(
+    rom: R,
+    manifest: &Manifest,
+) -> Option<u32> {
     let mut crc: u32 = 0;
-    for idx in 0..manifest.layers.len() {
-        let ok = stream_layer(rr, manifest, idx, |chunk| {
+    for layer in &manifest.layers {
+        let desc = LayerDesc { offset: layer.offset, len: layer.size };
+        if stream_layer(rom, &desc, |chunk| {
             for &b in chunk {
                 crc = crc.rotate_left(5) ^ b as u32;
             }
-        });
-        if !ok {
+        }, |_, _| ()).is_err() {
             return None;
         }
     }

--- a/n64llm/n64-rust/src/platform/cart.rs
+++ b/n64llm/n64-rust/src/platform/cart.rs
@@ -1,0 +1,12 @@
+use crate::io::rom_reader::RomReader;
+
+/// Abstraction over a ROM source (flat or banked).
+pub trait RomSource {
+    fn read_abs(&mut self, rom_abs_off: u64, dst: &mut [u8]) -> Result<(), ()>;
+}
+
+impl<T: RomReader + ?Sized> RomSource for &mut T {
+    fn read_abs(&mut self, rom_abs_off: u64, dst: &mut [u8]) -> Result<(), ()> {
+        if (**self).read(rom_abs_off, dst) { Ok(()) } else { Err(()) }
+    }
+}

--- a/n64llm/n64-rust/src/platform/mod.rs
+++ b/n64llm/n64-rust/src/platform/mod.rs
@@ -1,3 +1,4 @@
 pub mod pi;
 pub mod time;
+pub mod cart;
 

--- a/n64llm/n64-rust/src/platform/pi.rs
+++ b/n64llm/n64-rust/src/platform/pi.rs
@@ -1,7 +1,15 @@
-use crate::config::{BURST_BYTES, ROM_LIMIT_BYTES};
-use crate::n64_sys::pi_read;
+use core::ptr::{read_volatile, write_volatile};
+use crate::n64_sys::{
+    PI_DRAM_ADDR_REG, PI_CART_ADDR_REG, PI_RD_LEN_REG, PI_STATUS_REG,
+    PI_STATUS_DMA_BUSY, CART_ROM_BASE,
+};
 
 pub const CART_BASE: u64 = 0x1000_0000; // N64 cart PI bus base
+
+#[inline(always)]
+fn pi_busy() -> bool {
+    unsafe { (read_volatile(PI_STATUS_REG as *const u32) & PI_STATUS_DMA_BUSY) != 0 }
+}
 
 #[derive(Debug, Copy, Clone)]
 pub enum PiError {
@@ -10,9 +18,25 @@ pub enum PiError {
     Oob,
 }
 
+/// Kick off a PI DMA read but do NOT wait for completion.
+pub unsafe fn pi_dma_start(dst: *mut u8, cart_addr: u32, len: u32) {
+    // Wait if a previous DMA is in flight.
+    while pi_busy() {}
+    write_volatile(PI_DRAM_ADDR_REG as *mut u32, dst as u32);
+    write_volatile(PI_CART_ADDR_REG as *mut u32, cart_addr);
+    write_volatile(PI_RD_LEN_REG  as *mut u32, len - 1);
+}
+
+/// Wait for any outstanding PI DMA to finish.
+#[inline(always)]
+pub fn pi_dma_wait_idle() {
+    while pi_busy() {}
+}
+
 /// Uses low-level PI to DMA chunks directly into RDRAM.
 pub fn pi_dma_read(rom_abs_off: u64, dst: &mut [u8]) -> Result<(), PiError> {
-    // Reject ranges beyond configured ROM window.
+    use crate::config::{ROM_LIMIT_BYTES, BURST_BYTES};
+    if dst.is_empty() { return Ok(()); }
     let end = rom_abs_off
         .checked_add(dst.len() as u64)
         .ok_or(PiError::Oob)?;
@@ -20,16 +44,15 @@ pub fn pi_dma_read(rom_abs_off: u64, dst: &mut [u8]) -> Result<(), PiError> {
         return Err(PiError::Oob);
     }
 
-    // Transfer in bursts; pi_read waits for DMA completion internally.
     let mut done = 0usize;
     while done < dst.len() {
         let chunk = core::cmp::min(dst.len() - done, BURST_BYTES);
-        let rom_addr = (CART_BASE + rom_abs_off + done as u64) as u32;
+        let rom_addr = (CART_ROM_BASE + rom_abs_off + done as u64) as u32;
         unsafe {
-            pi_read(dst.as_mut_ptr().add(done), rom_addr, chunk as u32);
+            pi_dma_start(dst.as_mut_ptr().add(done), rom_addr, chunk as u32);
+            pi_dma_wait_idle();
         }
         done += chunk;
     }
-
     Ok(())
 }

--- a/n64llm/n64-rust/src/stream/mod.rs
+++ b/n64llm/n64-rust/src/stream/mod.rs
@@ -1,2 +1,3 @@
 pub mod streamer;
+pub mod prefetch;
 

--- a/n64llm/n64-rust/src/stream/prefetch.rs
+++ b/n64llm/n64-rust/src/stream/prefetch.rs
@@ -1,0 +1,72 @@
+//! Double-buffered ROM prefetch for streaming large layers.
+//! Safe API; uses async PI DMA under the hood.
+
+use crate::platform::pi::{pi_dma_start, pi_dma_wait_idle};
+use crate::platform::cart::RomSource;
+use crate::weights::weights_rel_to_cart_off;
+
+pub struct Prefetcher<'a, R: RomSource> {
+    rom: R,
+    cart_off: u64,     // absolute cart offset to the start of the tensor
+    len: u64,          // total bytes remaining
+    buf_a: &'a mut [u8],
+    buf_b: &'a mut [u8],
+    cur: usize,        // 0 => A has data, 1 => B has data
+    filled: [usize;2], // valid bytes in each buffer
+}
+
+impl<'a, R: RomSource> Prefetcher<'a, R> {
+    pub fn new(mut rom: R, weights_rel_off: u64, total_len: u64,
+               buf_a: &'a mut [u8], buf_b: &'a mut [u8]) -> Self {
+        let cart_off = weights_rel_to_cart_off(weights_rel_off);
+        // Prime A synchronously so callers can read immediately.
+        let first = core::cmp::min(total_len as usize, buf_a.len());
+        rom.read_abs(cart_off, &mut buf_a[..first]).unwrap();
+        Self { rom, cart_off: cart_off + first as u64, len: total_len - first as u64,
+               buf_a, buf_b, cur: 0, filled: [first, 0] }
+    }
+
+    /// Begin fetching the next chunk into the "other" buffer (non-blocking kick).
+    pub fn prefetch_next(&mut self) {
+        if self.len == 0 { return; }
+        let tgt = if self.cur == 0 { 1 } else { 0 };
+        let buf = if tgt == 0 { &mut self.buf_a } else { &mut self.buf_b };
+        let want = core::cmp::min(self.len as usize, buf.len());
+        unsafe {
+            let dst = buf.as_mut_ptr();
+            let cart_addr = (crate::n64_sys::CART_ROM_BASE + self.cart_off) as u32;
+            pi_dma_start(dst, cart_addr, want as u32);
+        }
+    }
+
+    /// Wait for any in-flight DMA and swap buffers; return filled slice.
+    pub fn next_block(&mut self) -> Option<&[u8]> {
+        if self.len == 0 && self.filled[self.cur] == 0 { return None; }
+        // If a prefetch was kicked, finalize it and update accounting.
+        pi_dma_wait_idle();
+        if self.filled[self.cur] == 0 {
+            // We were waiting on the other buffer; mark it filled now.
+            let tgt = if self.cur == 0 { 1 } else { 0 };
+            let got = core::cmp::min(self.len as usize,
+                                     if tgt==0 { self.buf_a.len() } else { self.buf_b.len() });
+            self.filled[tgt] = got;
+            self.cart_off += got as u64;
+            self.len -= got as u64;
+            self.cur = tgt;
+        }
+        let (slice, got) = if self.cur == 0 {
+            (&self.buf_a[..self.filled[0]], self.filled[0])
+        } else {
+            (&self.buf_b[..self.filled[1]], self.filled[1])
+        };
+        // Prepare the other buffer for the next call.
+        let tgt = if self.cur == 0 { 1 } else { 0 };
+        if self.len > 0 {
+            self.filled[tgt] = 0; // mark empty while DMA runs
+            self.prefetch_next();
+        }
+        Some(slice)
+    }
+
+    pub fn remaining(&self) -> u64 { self.len + self.filled[self.cur] as u64 }
+}


### PR DESCRIPTION
## Summary
- expose non-blocking PI DMA start and wait helpers
- introduce double-buffer prefetcher for ROM streaming
- stream layers using prefetcher and add config for block size

## Testing
- `PACK_ROM=1 cargo build --release` *(fails: missing assets and unsupported features)*

------
https://chatgpt.com/codex/tasks/task_e_689f7581eefc8323acb793d38dc5cff2