### PR TITLE
Add streaming CRC32 check and fix prefetcher

### DIFF
--- a/n64llm/n64-rust/src/diag/manifest_check.rs
+++ b/n64llm/n64-rust/src/diag/manifest_check.rs
@@ -1,5 +1,6 @@
 use crate::{display, io::rom_reader::RomReader, weights_manifest::ManifestView};
 use crate::weights::weights_rel_to_cart_off;
+use alloc::format;
 
 pub fn manifest_check<R: RomReader>(rr: &mut R, man_bytes: &'static [u8], weights_size: u64) {
     display::print_line("=== MANIFEST CHECK ===");

--- a/n64llm/n64-rust/src/diag/mod.rs
+++ b/n64llm/n64-rust/src/diag/mod.rs
@@ -3,3 +3,4 @@ pub mod weights_info;
 pub mod manifest_check;
 pub mod stream_bench;
 pub mod decode_once;
+pub mod stream_crc;

--- a/n64llm/n64-rust/src/diag/stream_bench.rs
+++ b/n64llm/n64-rust/src/diag/stream_bench.rs
@@ -5,6 +5,7 @@ use crate::stream::streamer::stream_entry;
 use crate::display;
 use crate::config::BENCH_MAX_BYTES_PER_ENTRY;
 use crate::util::adler32;
+use alloc::format;
 
 pub fn run<R: RomReader>(rr: &mut R, man_bytes: &'static [u8]) {
     display::print_line("=== STREAM BENCH ===");

--- a/n64llm/n64-rust/src/diag/stream_crc.rs
+++ b/n64llm/n64-rust/src/diag/stream_crc.rs
@@ -1,0 +1,42 @@
+use crate::{display, io::rom_reader::RomReader, weights_manifest::ManifestView};
+use crate::weights::weights_rel_to_cart_off;
+use crate::stream::streamer::stream_entry;
+use crate::util::crc32;
+use alloc::format;
+
+pub fn run<R: RomReader>(rr: &mut R, man_bytes: &'static [u8]) {
+    display::print_line("=== STREAM CRC ===");
+    let view = match ManifestView::new(man_bytes) {
+        Ok(v) => v,
+        Err(_) => { display::print_line("Manifest parse ERR"); return; }
+    };
+    let mut final_crc: u32 = !0u32;
+    let mut idx: u32 = 0;
+    let ver = view.version();
+    let _ = view.for_each(|e| {
+        let cart_off = weights_rel_to_cart_off(e.offset as u64);
+        let mut crc: u32 = !0u32;
+        let _ = stream_entry(rr, cart_off, e.size as u64, |chunk| {
+            crc = crc32::crc32_update(crc, chunk);
+            final_crc = crc32::crc32_update(final_crc, chunk);
+        });
+        if ver >= 2 {
+            let got = crc32::crc32_finish(crc);
+            match e.crc32 {
+                Some(exp) if got == exp => {
+                    display::print_line(&format!("[{idx:02}] {:16} CRC={:08X} verified \u{2713}", e.name, got));
+                }
+                Some(exp) => {
+                    display::print_line(&format!("[{idx:02}] {:16} CRC={:08X} expected={:08X} CRC mismatch", e.name, got, exp));
+                }
+                None => {
+                    display::print_line(&format!("[{idx:02}] {:16} CRC={:08X} (no ref)", e.name, got));
+                }
+            }
+        }
+        idx += 1;
+        true
+    });
+    let final_crc = crc32::crc32_finish(final_crc);
+    display::print_line(&format!("Final CRC32 {:08X}", final_crc));
+}

--- a/n64llm/n64-rust/src/diag/weights_info.rs
+++ b/n64llm/n64-rust/src/diag/weights_info.rs
@@ -1,5 +1,6 @@
 use crate::weights::{weights_rel_to_cart_off, weights_rom_base, weights_rom_size};
 use crate::{display, io::rom_reader::RomReader};
+use alloc::format;
 
 pub fn show_weights_info<R: RomReader>(rr: &mut R) {
     let base = weights_rom_base();

--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -46,19 +46,13 @@ pub extern "C" fn main() -> ! {
         &weights_manifest::MODEL_MANIFEST,
         weights::weights_rom_size(),
     );
-
+    diag::stream_crc::run(&mut rr, &crate::weights_manifest::MODEL_MANIFEST);
     diag::stream_bench::run(&mut rr, &crate::weights_manifest::MODEL_MANIFEST);
     diag::decode_once::run(&mut rr, &crate::weights_manifest::MODEL_MANIFEST, 42);
     wait_for_start_button();
 
     let manifest = manifest::load();
     display::print_line(&format!("Manifest layers: {}", manifest.layers.len()));
-
-    display::print_line("Running ROM checksum...");
-    match model::stream::checksum_all_layers(&mut rr, &manifest) {
-        Some(sum) => display::print_line(&format!("Checksum: 0x{:08X}", sum)),
-        None => display::print_line("Checksum failed"),
-    }
 
     // Initialize memory management system.
     let mut memory = unsafe { memory_manager::init() };

--- a/n64llm/n64-rust/src/platform/pi.rs
+++ b/n64llm/n64-rust/src/platform/pi.rs
@@ -4,8 +4,6 @@ use crate::n64_sys::{
     PI_STATUS_DMA_BUSY, CART_ROM_BASE,
 };
 
-pub const CART_BASE: u64 = 0x1000_0000; // N64 cart PI bus base
-
 #[inline(always)]
 fn pi_busy() -> bool {
     unsafe { (read_volatile(PI_STATUS_REG as *const u32) & PI_STATUS_DMA_BUSY) != 0 }

--- a/n64llm/n64-rust/src/stream/prefetch.rs
+++ b/n64llm/n64-rust/src/stream/prefetch.rs
@@ -47,14 +47,16 @@ impl<'a, R: RomSource> Prefetcher<'a, R> {
         if self.filled[self.cur] == 0 {
             // We were waiting on the other buffer; mark it filled now.
             let tgt = if self.cur == 0 { 1 } else { 0 };
-            let got = core::cmp::min(self.len as usize,
-                                     if tgt==0 { self.buf_a.len() } else { self.buf_b.len() });
+            let got = core::cmp::min(
+                self.len as usize,
+                if tgt == 0 { self.buf_a.len() } else { self.buf_b.len() }
+            );
             self.filled[tgt] = got;
             self.cart_off += got as u64;
             self.len -= got as u64;
             self.cur = tgt;
         }
-        let (slice, got) = if self.cur == 0 {
+        let (slice, _got) = if self.cur == 0 {
             (&self.buf_a[..self.filled[0]], self.filled[0])
         } else {
             (&self.buf_b[..self.filled[1]], self.filled[1])
@@ -65,6 +67,8 @@ impl<'a, R: RomSource> Prefetcher<'a, R> {
             self.filled[tgt] = 0; // mark empty while DMA runs
             self.prefetch_next();
         }
+        // Mark current buffer as consumed so the next call swaps.
+        self.filled[self.cur] = 0;
         Some(slice)
     }
 

--- a/n64llm/n64-rust/src/util/crc32.rs
+++ b/n64llm/n64-rust/src/util/crc32.rs
@@ -1,0 +1,15 @@
+// Simple bitwise CRC32 (poly 0xEDB88320); fast enough vs PI/compute.
+pub fn crc32_update(mut crc: u32, buf: &[u8]) -> u32 {
+    // streaming-friendly: pass crc from previous call; init with !0
+    for &b in buf {
+        let mut x = (crc ^ (b as u32)) & 0xFF;
+        for _ in 0..8 {
+            let lsb = x & 1;
+            x >>= 1;
+            if lsb != 0 { x ^= 0xEDB88320; }
+        }
+        crc = (crc >> 8) ^ x;
+    }
+    crc
+}
+pub fn crc32_finish(crc: u32) -> u32 { !crc }

--- a/n64llm/n64-rust/src/util/mod.rs
+++ b/n64llm/n64-rust/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod adler32;
 pub mod f32le;
+pub mod crc32;
 

--- a/n64llm/n64-rust/src/weights.rs
+++ b/n64llm/n64-rust/src/weights.rs
@@ -11,7 +11,7 @@ extern "C" {
 }
 #[inline(always)]
 pub fn weights_rom_base() -> u32 {
-    0x1000_0000 + unsafe { &__weights_rom_start as *const _ as u32 }
+    crate::n64_sys::CART_ROM_BASE as u32 + unsafe { &__weights_rom_start as *const _ as u32 }
 }
 #[inline(always)]
 pub fn weights_rom_size() -> u64 {
@@ -20,5 +20,5 @@ pub fn weights_rom_size() -> u64 {
 #[inline(always)]
 pub fn weights_rel_to_cart_off(rel: u64) -> u64 {
     let abs = weights_rom_base() as u64 + rel;
-    abs - crate::platform::pi::CART_BASE
+    abs - crate::n64_sys::CART_ROM_BASE as u64
 }


### PR DESCRIPTION
## Summary
- add streaming CRC32 utility and checksum pass
- verify optional per-layer CRCs from manifest v2
- fix prefetcher buffer swap bug and unify cart constants

## Testing
- `cargo check` *(fails: missing weights assets and experimental attributes)*

------
https://chatgpt.com/codex/tasks/task_e_689f8372713c8323a31266d7b2f78067