### PR TITLE
Add emu smoke path and ROM packing helper

### DIFF
--- a/n64llm/n64-rust/n64.ld
+++ b/n64llm/n64-rust/n64.ld
@@ -28,16 +28,15 @@ SECTIONS
 
     /* Manifest and weights sections */
     __manifest_rom_start = .;
-    .model_manifest ALIGN(64) :
-    {
-      KEEP(*(.model_manifest*))
+    .model_manifest : ALIGN(64) {
+        KEEP(*(.model_manifest))
     } > ROM
     __manifest_rom_end = .;
 
     __weights_rom_start = .;
-    .model_weights ALIGN(64) :
-    {
-         KEEP(*(.model_weights*))
+    .model_weights : ALIGN(64) {
+        KEEP(*(.model_weights))
+        . = ALIGN(64);
     } > ROM
     __weights_rom_end = .;
 

--- a/n64llm/n64-rust/src/diag/emu_smoke.rs
+++ b/n64llm/n64-rust/src/diag/emu_smoke.rs
@@ -1,0 +1,33 @@
+use crate::platform::cart::RomSource;
+use crate::manifest;
+use crate::stream::prefetch::Prefetcher;
+use crate::display::{show_progress, print_line};
+use crate::util::crc32::{crc32_update, crc32_finish};
+use alloc::format;
+
+pub fn run<R: RomSource + Copy>(rom: R) {
+    let man = manifest::load();
+
+    let mut total_bytes: u64 = 0;
+    for l in &man.layers { total_bytes += l.size as u64; }
+    print_line("EMU SMOKE: streaming all layers");
+    show_progress(0, total_bytes as usize);
+
+    let mut crc: u32 = !0;
+    let mut done: u64 = 0;
+
+    for (i, l) in man.layers.iter().enumerate() {
+        // 2×32KiB static buffers already set in streamer config.
+        static mut A: [u8; crate::config::STREAM_BLOCK_BYTES] = [0; crate::config::STREAM_BLOCK_BYTES];
+        static mut B: [u8; crate::config::STREAM_BLOCK_BYTES] = [0; crate::config::STREAM_BLOCK_BYTES];
+        let mut pf = unsafe { Prefetcher::new(rom, l.offset as u64, l.size as u64, &mut A, &mut B) };
+        while let Some(chunk) = pf.next_block() {
+            crc = crc32_update(crc, chunk);
+            done += chunk.len() as u64;
+            show_progress(done as usize, total_bytes as usize);
+        }
+        print_line(&format!("Layer {} OK", i));
+    }
+    let crc = crc32_finish(crc);
+    print_line(&format!("EMU SMOKE done, CRC32 = 0x{:08X}", crc));
+}

--- a/n64llm/n64-rust/src/diag/mod.rs
+++ b/n64llm/n64-rust/src/diag/mod.rs
@@ -4,3 +4,4 @@ pub mod manifest_check;
 pub mod stream_bench;
 pub mod decode_once;
 pub mod stream_crc;
+pub mod emu_smoke;

--- a/n64llm/n64-rust/src/display.rs
+++ b/n64llm/n64-rust/src/display.rs
@@ -416,6 +416,14 @@ pub fn keyboard_input(buffer: &mut String) -> bool {
 
 // Display a simple progress indicator while running inference.
 pub fn show_progress(current: usize, total: usize) {
+    const THROTTLE: usize = 4;
+    static mut COUNT: usize = 0;
+    unsafe {
+        COUNT = COUNT.wrapping_add(1);
+        if COUNT % THROTTLE != 0 && current < total {
+            return;
+        }
+    }
     let bar_width = 20;
     let filled = bar_width * current / total;
     let mut bar = String::new();

--- a/scripts/emu_smoke.sh
+++ b/scripts/emu_smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 0) Sanity: confirm assets exist where the code expects them.
+ASSETS="n64llm/n64-rust/assets"
+[[ -f "$ASSETS/weights.bin" ]] || { echo "Joshua: please move your weights to $ASSETS/weights.bin"; exit 1; }
+[[ -f "$ASSETS/weights.manifest.bin" ]] || { echo "Joshua: please move your manifest to $ASSETS/weights.manifest.bin"; exit 1; }
+
+# 1) Build (no moving binaries).
+PACK_ROM=1 cargo build --release
+
+# 2) Find the produced ROM and run emulator if available.
+ROM="$(ls -1 target/**/release/*.z64 2>/dev/null | head -n1 || true)"
+if [[ -z "${ROM}" ]]; then
+  echo "No .z64 found. Joshua: please tell me where your packed ROM is written."
+  exit 1
+fi
+echo "ROM: ${ROM}"
+
+# Try ares if on PATH; otherwise just print path.
+if command -v ares >/dev/null 2>&1; then
+  ares "${ROM}"
+else
+  echo "ares not found. Joshua: launch your emulator manually with ${ROM}"
+fi


### PR DESCRIPTION
## Summary
- Align manifest/weight sections to 64-byte boundaries with explicit tail padding
- Add diagnostic `emu_smoke` to stream all layers and compute a CRC
- Provide `scripts/emu_smoke.sh` for one-command build and emulator launch
- Throttle progress updates to reduce UI spam

## Testing
- `scripts/emu_smoke.sh` *(fails: Joshua: please move your weights to n64llm/n64-rust/assets/weights.bin)*


------
https://chatgpt.com/codex/tasks/task_e_689f86308c748323a234c3a989767dfa