### PR TITLE
Add GPT-2 export and validation tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 n64llm/n64-rust/assets/weights.bin
 n64llm/n64-rust/assets/weights.manifest.bin
+# N64 weights blobs
+n64llm/n64-rust/assets/*.bin
+artifacts/exports/**

--- a/scripts/export_smoke_and_clean.sh
+++ b/scripts/export_smoke_and_clean.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ASSETS="n64llm/n64-rust/assets"
+BIN="$ASSETS/weights.bin"
+MAN="$ASSETS/weights.manifest.bin"
+
+# 0) Export real or debug
+MODE="${1:-debug}"   # "debug" or "real"
+if [[ "$MODE" == "real" ]]; then
+  # Example: keep last 8 blocks of gpt2-medium as fp16 (tweak as needed)
+  python tools/export_gpt2_n64.py --model gpt2-medium --dtype fp16 --keep-layers 8 --out-dir "$ASSETS"
+else
+  python tools/make_debug_weights.py --out-dir "$ASSETS" --chunks 8 --chunkKB 64
+fi
+
+# 1) Validate
+python tools/validate_weights.py --bin "$BIN" --man "$MAN"
+
+# 2) Optional: build + emu smoke
+if [[ "${RUN_SMOKE:-1}" == "1" ]]; then
+  scripts/emu_smoke.sh || true
+fi
+
+# 3) ALWAYS CLEAN (avoid binaries in PRs)
+rm -f "$BIN" "$MAN"
+echo "[CLEAN] removed $BIN and $MAN"

--- a/tools/export_gpt2_n64.py
+++ b/tools/export_gpt2_n64.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Minimal GPT-2 exporter → n64 format (64B aligned). fp16 by default.
+# Requires: torch, transformers
+import argparse, os, json, time, struct, zlib
+from pathlib import Path
+
+def align64(f):
+    need = (-f.tell()) & 63
+    if need: f.write(b"\x00"*need)
+    return need
+
+def write_manifest_v2(path, align, entries):
+    # entries: list of (name:str, off:int, size:int, crc32:int)
+    with open(path, "wb") as m:
+        m.write(b"N64W")
+        m.write(struct.pack("<H", 2))           # ver=2 (CRC aware)
+        m.write(struct.pack("<H", align))
+        m.write(struct.pack("<I", len(entries)))
+        for name, off, size, crc in entries:
+            nb = name.encode("utf-8")
+            m.write(struct.pack("<H", len(nb)))
+            m.write(nb)
+            m.write(struct.pack("<I", off))
+            m.write(struct.pack("<I", size))
+            m.write(struct.pack("<I", crc))
+
+def collect_params_gpt2(model, keep_layers=None):
+    # Keep embeddings, final ln_f, lm_head, and a subset of blocks.
+    # keep_layers=None keeps all; otherwise keep the last N transformer blocks.
+    wanted = set()
+    if keep_layers is not None:
+        L = len(model.transformer.h)
+        keep = set(range(max(0, L - keep_layers), L))
+    else:
+        keep = None
+
+    for n, p in model.named_parameters():
+        if n.startswith("transformer.wte") or n.startswith("transformer.wpe"):
+            wanted.add(n)
+        elif n.startswith("transformer.ln_f"):
+            wanted.add(n)
+        elif n.startswith("lm_head"):
+            wanted.add(n)
+        elif n.startswith("transformer.h."):
+            # block index
+            try:
+                blk = int(n.split(".")[2])
+            except Exception:
+                continue
+            if (keep is None) or (blk in keep):
+                wanted.add(n)
+    # Deterministic order: embeddings → blocks (by idx) → ln_f → lm_head
+    def key(n):
+        if n.startswith("transformer.wte"): return (0, 0, n)
+        if n.startswith("transformer.wpe"): return (0, 1, n)
+        if n.startswith("transformer.h."):
+            parts = n.split(".")
+            return (1, int(parts[2]), n)
+        if n.startswith("transformer.ln_f"): return (2, 0, n)
+        if n.startswith("lm_head"):          return (3, 0, n)
+        return (9, 0, n)
+    return [n for n in sorted(wanted, key=key)]
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="gpt2", help="HF id or local path (e.g. gpt2-medium)")
+    ap.add_argument("--dtype", choices=["fp16","fp32"], default="fp16")
+    ap.add_argument("--keep-layers", type=int, default=None, help="Keep last N blocks (prunes depth)")
+    ap.add_argument("--out-dir", default="n64llm/n64-rust/assets", help="Output dir for weights.bin/manifest.bin")
+    ap.add_argument("--tune-config", default=None, help="JSON file to archive alongside export metadata")
+    ap.add_argument("--no-smoke", action="store_true", help="Skip smoke run")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_bin = out_dir / "weights.bin"
+    out_man = out_dir / "weights.manifest.bin"
+
+    # --- load model
+    import torch
+    from transformers import AutoModelForCausalLM
+    model = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype=(torch.float16 if args.dtype=="fp16" else torch.float32), low_cpu_mem_usage=True)
+    model = model.to("cpu")
+    model.eval()
+
+    names = collect_params_gpt2(model, keep_layers=args.keep_layers)
+
+    entries = []
+    with open(out_bin, "wb") as bout:
+        for name in names:
+            tensor = dict(model.named_parameters())[name].detach().cpu()
+            if args.dtype == "fp16":
+                tensor = tensor.to(torch.float16)
+            data = tensor.contiguous().numpy().tobytes()
+            align64(bout)
+            off = bout.tell()
+            bout.write(data)
+            crc = zlib.crc32(data) & 0xFFFFFFFF
+            entries.append((name, off, len(data), crc))
+
+    write_manifest_v2(out_man, 64, entries)
+
+    # archive export metadata (for reproducibility)
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    art = Path("artifacts/exports")/stamp
+    art.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "model": args.model,
+        "dtype": args.dtype,
+        "keep_layers": args.keep_layers,
+        "bin": str(out_bin),
+        "man": str(out_man),
+        "count": len(entries),
+        "bytes": sum(e[2] for e in entries),
+    }
+    if args.tune_config:
+        with open(args.tune_config, "r") as f:
+            cfg = json.load(f)
+        with open(art/"tune.json","w") as f:
+            json.dump(cfg, f, indent=2)
+        with open(out_dir/"last_export_tune.json","w") as f:
+            json.dump(cfg, f, indent=2)
+    with open(art/"export.json","w") as f:
+        json.dump(meta, f, indent=2)
+
+    print(f"[OK] export complete → {out_bin} + {out_man}")
+    print(f"     entries={meta['count']} bytes={meta['bytes']}")
+    # Optional: validate layout using existing validator
+    # (supports v1 today; we'll update it below to handle v2)
+    # End.
+if __name__ == "__main__":
+    main()

--- a/tools/make_debug_weights.py
+++ b/tools/make_debug_weights.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Produce a small test blob + manifest v2 to exercise ROM streaming/CRC.
+import argparse, os, struct, zlib
+from pathlib import Path
+
+def align64(f):
+    need = (-f.tell()) & 63
+    if need: f.write(b"\x00"*need)
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--out-dir", default="n64llm/n64-rust/assets")
+ap.add_argument("--chunks", type=int, default=8)
+ap.add_argument("--chunkKB", type=int, default=64) # 8*64KB = 512KB total default
+args = ap.parse_args()
+
+out_dir = Path(args.out_dir); out_dir.mkdir(parents=True, exist_ok=True)
+binp = out_dir/"weights.bin"
+manp = out_dir/"weights.manifest.bin"
+
+entries=[]
+with open(binp,"wb") as f:
+    for i in range(args.chunks):
+        align64(f)
+        off = f.tell()
+        data = bytes([(i*31 + j) & 0xFF for j in range(args.chunkKB*1024)])
+        f.write(data)
+        crc = zlib.crc32(data) & 0xFFFFFFFF
+        entries.append((f"debug_chunk_{i}", off, len(data), crc))
+
+with open(manp, "wb") as m:
+    m.write(b"N64W")
+    m.write(struct.pack("<H", 2)); m.write(struct.pack("<H", 64))
+    m.write(struct.pack("<I", len(entries)))
+    for name, off, size, crc in entries:
+        nb=name.encode("utf-8")
+        m.write(struct.pack("<H", len(nb))); m.write(nb)
+        m.write(struct.pack("<I", off)); m.write(struct.pack("<I", size))
+        m.write(struct.pack("<I", crc))
+print(f"[OK] debug weights → {binp} + {manp}")

--- a/tools/validate_weights.py
+++ b/tools/validate_weights.py
@@ -1,54 +1,50 @@
-import argparse, os, struct, sys
-
+#!/usr/bin/env python3
+import argparse, os, struct, sys, zlib
 
 def read_exact(f, n):
-    b = f.read(n)
-    if len(b) != n:
-        raise EOFError
+    b=f.read(n); 
+    if len(b)!=n: raise EOFError
     return b
 
 def parse_manifest(path):
-    with open(path, "rb") as f:
-        magic = read_exact(f, 4)
-        if magic != b"N64W":
-            raise SystemExit("Bad magic")
-        ver, align = struct.unpack("<HH", read_exact(f, 4))
-        if ver != 1:
-            raise SystemExit(f"Bad version: {ver}")
-        count, = struct.unpack("<I", read_exact(f, 4))
-        entries = []
+    with open(path,"rb") as f:
+        if read_exact(f,4)!=b"N64W": raise SystemExit("Bad magic")
+        ver, align = struct.unpack("<HH", read_exact(f,4))
+        if ver not in (1,2): raise SystemExit(f"Bad version: {ver}")
+        count, = struct.unpack("<I", read_exact(f,4))
+        entries=[]
         for _ in range(count):
-            nlen, = struct.unpack("<H", read_exact(f, 2))
-            name = read_exact(f, nlen).decode("utf-8", "replace")
-            off, size = struct.unpack("<II", read_exact(f, 8))
-            entries.append((name, off, size))
-        return align, entries
+            nlen, = struct.unpack("<H", read_exact(f,2))
+            name = read_exact(f,nlen).decode("utf-8","replace")
+            off, size = struct.unpack("<II", read_exact(f,8))
+            crc = struct.unpack("<I", read_exact(f,4))[0] if ver>=2 else None
+            entries.append((name, off, size, crc))
+        return ver, align, entries
 
 def main():
-    ap = argparse.ArgumentParser()
+    ap=argparse.ArgumentParser()
     ap.add_argument("--bin", required=True)
     ap.add_argument("--man", required=True)
-    args = ap.parse_args()
+    args=ap.parse_args()
 
-    size = os.path.getsize(args.bin)
-    align, entries = parse_manifest(args.man)
+    size=os.path.getsize(args.bin)
+    ver, align, entries = parse_manifest(args.man)
 
-    used = []
-    for name, off, sz in entries:
-        if off % align != 0:
-            print(f"[FAIL] {name}: offset {off} not aligned to {align}")
-            sys.exit(2)
-        if off + sz > size:
-            print(f"[FAIL] {name}: out of bounds ({off}+{sz}>{size})")
-            sys.exit(2)
-        used.append((off, off + sz, name))
+    used=[]
+    with open(args.bin,"rb") as f:
+        for name, off, sz, crc in entries:
+            if off%align!=0: print(f"[FAIL] {name}: off {off} not aligned {align}"); sys.exit(2)
+            if off+sz>size:  print(f"[FAIL] {name}: OOB ({off}+{sz}>{size})"); sys.exit(2)
+            used.append((off, off+sz, name))
+            if crc is not None:
+                f.seek(off); data = f.read(sz)
+                c = zlib.crc32(data) & 0xFFFFFFFF
+                if c != crc:
+                    print(f"[FAIL] {name}: CRC mismatch exp=0x{crc:08X} got=0x{c:08X}")
+                    sys.exit(2)
     used.sort()
-    for (s1, e1, n1), (s2, e2, n2) in zip(used, used[1:]):
-        if s2 < e1:
-            print(f"[FAIL] overlap: {n1} [{s1},{e1}) with {n2} [{s2},{e2})")
-            sys.exit(2)
+    for (s1,e1,n1),(s2,e2,n2) in zip(used,used[1:]):
+        if s2<e1: print(f"[FAIL] overlap: {n1}[{s1},{e1}) vs {n2}[{s2},{e2})"); sys.exit(2)
 
-    print(f"[OK] {len(entries)} entries; bin={size} bytes; align={align}")
-
-if __name__ == "__main__":
-    main()
+    print(f"[OK] {len(entries)} entries; bin={size} bytes; align={align}; ver={ver}")
+if __name__=="__main__": main()


### PR DESCRIPTION
## Summary
- add script to export GPT-2 weights into aligned N64 binary and manifest
- add debug weight generator for CRC/testing
- support manifest v2 with CRC in validator and add wrapper script that validates and cleans

## Testing
- `scripts/export_smoke_and_clean.sh debug` *(fails: could not find Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_689f8b1390948323b6b3add17eb2ab74