### PR TITLE
Patch cargo-n64 install step and quiet warnings

### DIFF
--- a/n64llm/n64-rust/src/model/stream.rs
+++ b/n64llm/n64-rust/src/model/stream.rs
@@ -65,7 +65,7 @@ pub fn checksum_all_layers<R: RomSource + Copy>(
 mod t_stream {
     use super::*;
     use crate::platform::host_cart::VecRom;
-    use crate::stream::prefetch::Prefetcher;
+    // use crate::stream::prefetch::Prefetcher; // not needed in this host-only test
     use alloc::vec::Vec;
 
     #[test]

--- a/n64llm/n64-rust/src/weights_manifest.rs
+++ b/n64llm/n64-rust/src/weights_manifest.rs
@@ -78,10 +78,9 @@ fn rd_u32_le(b: &[u8], i: &mut usize) -> Result<u32, ManErr> {
 
 impl<'a> ManifestView<'a> {
     pub fn new(bytes: &'a [u8]) -> Result<Self, ManErr> {
-        let mut i = 0;
         if bytes.len() < 12 { return Err(ManErr::Truncated); }
         if &bytes[0..4] != b"N64W" { return Err(ManErr::BadMagic); }
-        i = 4;
+        let mut i = 4;
         let ver = rd_u16_le(bytes, &mut i)?;
         if ver != 1 && ver != 2 { return Err(ManErr::BadVersion); }
         let align = rd_u16_le(bytes, &mut i)?;

--- a/tools/install_cargo_n64.sh
+++ b/tools/install_cargo_n64.sh
@@ -1,21 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Always prefer a pinned Git commit known to compile on our runner.
-# If upstream breaks, add another rev below and try again.
-REVS=(
-  "main"            # try latest main first
-  # "v0.3.0"        # uncomment if a future tag is stable for us
-)
+TOOLCHAIN="+nightly"
+REPO="https://github.com/rust-console/cargo-n64"
 
-for rev in "${REVS[@]}"; do
-  if cargo +nightly install cargo-n64 \
-      --git https://github.com/rust-console/cargo-n64 \
-      --branch "$rev" --locked; then
-    echo "cargo-n64 installed from $rev"
-    exit 0
-  fi
-done
+echo "[cargo-n64] Trying upstream main first…"
+if cargo ${TOOLCHAIN} install cargo-n64 --git "${REPO}" --branch main --locked; then
+  echo "[cargo-n64] Installed from upstream main."
+  exit 0
+fi
 
-echo "ERROR: cargo-n64 could not be installed from any pinned revs." >&2
-exit 1
+echo "[cargo-n64] Upstream main failed, applying tiny patch to remove .backtrace()…"
+workdir="$(mktemp -d)"
+git clone --depth=1 "${REPO}" "${workdir}/cargo-n64"
+pushd "${workdir}/cargo-n64" >/dev/null
+
+# 1) Remove the now-useless crate attribute.
+perl -0777 -pe 's/#!\[feature\(backtrace\)\]\n?//s' -i src/lib.rs
+
+# 2) Strip the entire `if let Some(backtrace) = error.backtrace() { … }` block.
+perl -0777 -pe 's/if\s+let\s+Some\([^)]*\)\s*=\s*error\.backtrace\(\)\s*\{[^}]*\}\s*//s' -i src/lib.rs
+
+# Optional: print the error chain instead (harmless if not present in file layout)
+# perl -0777 -pe 's/eprintln!\(\{error\}\);\s*/eprintln!("{error}"); let mut s = error.source(); while let Some(c)=s { eprintln!("caused by: {c}"); s=c.source(); }/s' -i src/lib.rs || true
+
+cargo ${TOOLCHAIN} install --path . --locked
+popd >/dev/null
+echo "[cargo-n64] Installed from patched tree."
+


### PR DESCRIPTION
## Summary
- install cargo-n64, auto-patching out `backtrace()` when upstream fails
- silence unused Prefetcher import in host stream test
- drop redundant initialization in weights manifest parser

## Testing
- `cargo test --features host`

------
https://chatgpt.com/codex/tasks/task_e_689fa24525848323af751455124795cd