### PR TITLE
fix cargo-n64 install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
             --bin n64llm/n64-rust/assets/weights.bin \
             --man n64llm/n64-rust/assets/weights.manifest.bin --crc
 
-      - name: Install cargo-n64 (pinned)
+      - name: Install cargo-n64 (only on main pushes)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: bash tools/install_cargo_n64.sh
 
       - name: Build N64 ROM (release)

--- a/tools/install_cargo_n64.sh
+++ b/tools/install_cargo_n64.sh
@@ -1,30 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TOOLCHAIN="+nightly"
 REPO="https://github.com/rust-console/cargo-n64"
 
 echo "[cargo-n64] Trying upstream main first…"
-if cargo ${TOOLCHAIN} install cargo-n64 --git "${REPO}" --branch main --locked; then
+if cargo +nightly install cargo-n64 --git "$REPO" --branch main --locked; then
   echo "[cargo-n64] Installed from upstream main."
   exit 0
 fi
 
-echo "[cargo-n64] Upstream main failed, applying tiny patch to remove .backtrace()…"
+echo "[cargo-n64] Upstream failed; cloning and applying safe backtrace shim…"
 workdir="$(mktemp -d)"
-git clone --depth=1 "${REPO}" "${workdir}/cargo-n64"
-pushd "${workdir}/cargo-n64" >/dev/null
+git clone --depth=1 "$REPO" "$workdir/cargo-n64"
+pushd "$workdir/cargo-n64" >/dev/null
 
-# 1) Remove the now-useless crate attribute.
-perl -0777 -pe 's/#!\[feature\(backtrace\)\]\n?//s' -i src/lib.rs
+# 1) Remove obsolete feature gate (harmless if missing)
+sed -i '/^\s*#!\[feature(backtrace)\]\s*$/d' src/lib.rs || true
 
-# 2) Strip the entire `if let Some(backtrace) = error.backtrace() { … }` block.
-perl -0777 -pe 's/if\s+let\s+Some\([^)]*\)\s*=\s*error\.backtrace\(\)\s*\{[^}]*\}\s*//s' -i src/lib.rs
+# 2) Replace the expression instead of deleting the block:
+#    `if let Some(bt) = error.backtrace()` -> `if let Some(bt) = None::<&std::backtrace::Backtrace>`
+perl -0777 -pe 's/error\s*\.\s*backtrace\s*\(\s*\)/None::<&std::backtrace::Backtrace>/g' -i src/lib.rs
 
-# Optional: print the error chain instead (harmless if not present in file layout)
-# perl -0777 -pe 's/eprintln!\(\{error\}\);\s*/eprintln!("{error}"); let mut s = error.source(); while let Some(c)=s { eprintln!("caused by: {c}"); s=c.source(); }/s' -i src/lib.rs || true
-
-cargo ${TOOLCHAIN} install --path . --locked
+# Install the patched tool
+cargo +nightly install --path . --locked
 popd >/dev/null
 echo "[cargo-n64] Installed from patched tree."
-


### PR DESCRIPTION
## Summary
- replace cargo-n64 install script with safe backtrace shim
- run cargo-n64 install only on pushes to main in CI

## Testing
- `bash -n tools/install_cargo_n64.sh`
- `yamllint .github/workflows/ci.yml` *(fails: command not found)*
- `bash tools/install_cargo_n64.sh`

------
https://chatgpt.com/codex/tasks/task_e_689fa4467a9083239da4b48a3343d48b