### PR TITLE
Use explicit release profile for cargo-n64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build N64 ROM (release)
         working-directory: n64llm/n64-rust
-        run: cargo +nightly -Z build-std=core,alloc n64 build --release
+        run: cargo +nightly -Z build-std=core,alloc n64 build --profile release
 
       - name: Scrub ephemerals
         run: |

--- a/codex.md
+++ b/codex.md
@@ -18,7 +18,7 @@ After these tools are installed, build the Rust project with:
 
 ```bash
 cd n64llm/n64-rust
-cargo +nightly-2022-06-21 n64 build --release
+cargo +nightly-2022-06-21 n64 build --profile release
 ```
 
-This produces a bootable ROM under `target/mips-nintendo64-none/release/` which can be run in an emulator such as `mupen64plus`.
+This produces a bootable ROM under `target/n64/release/` which can be run in an emulator such as `mupen64plus`.

--- a/scripts/export_and_test.sh
+++ b/scripts/export_and_test.sh
@@ -15,7 +15,7 @@ python tools/validate_weights.py \
   --man n64llm/n64-rust/assets/weights.manifest.bin --crc
 
 # 2) Build ROM (nightly) with build-std only here
-( cd n64llm/n64-rust && cargo +nightly -Z build-std=core,alloc n64 build --release )
+( cd n64llm/n64-rust && cargo +nightly -Z build-std=core,alloc n64 build --profile release )
 
 # 3) Optional emu smoke (never moves binaries; asks where to place)
 ./scripts/emu_smoke.sh || true


### PR DESCRIPTION
## Summary
- build N64 ROM using `--profile release` instead of deprecated `--release`
- update helper script and codex docs to match

## Testing
- `cargo test --lib --features host`
- `cargo test --test host_sanity --features host`
- `cargo +nightly -Z build-std=core,alloc n64 build --profile release` *(fails: no such command: `n64`)*

------
https://chatgpt.com/codex/tasks/task_e_689fa6f1bf88832390260494ec3c647a