### PR TITLE
Fix cargo-n64 invocation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,15 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: bash tools/install_cargo_n64.sh
 
-      - name: Build N64 ROM (release)
+      - name: Build N64 ROM
         working-directory: n64llm/n64-rust
-        run: cargo +nightly -Z build-std=core,alloc n64 build --profile release
+        run: cargo +nightly -Z build-std=core,alloc n64 build
+
+      - name: Upload ROM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: n64-rom-debug
+          path: n64llm/n64-rust/target/n64/debug/*.n64
 
       - name: Scrub ephemerals
         run: |


### PR DESCRIPTION
## Summary
- build N64 ROM without passing a release profile to cargo-n64
- upload the debug `.n64` artifact from CI

## Testing
- `cargo test --lib --verbose --features host`
- `cargo test --test host_sanity --verbose --features host`
- `cargo +nightly -Z build-std=core,alloc n64 build` *(fails: One of `--ipl3` or `--ipl3-from-rom` are required)*

------
https://chatgpt.com/codex/tasks/task_e_689faa7d922083238ea8769dcbff2bf5