### PR TITLE
Implement manifest-driven inference and controller polling

### DIFF
--- a/n64llm/n64-rust/src/inference_engine.rs
+++ b/n64llm/n64-rust/src/inference_engine.rs
@@ -1,18 +1,20 @@
-use alloc::vec::Vec;
-use core::result::Result;
-use core::fmt;
-use crate::memory_manager::MemoryManager;
 use crate::display;
-use crate::{platform::pi, weights};
 use crate::manifest;
-use alloc::vec;
+use crate::memory_manager::MemoryManager;
+use crate::model::names;
 use crate::n64_math;
+use crate::{platform::pi, weights};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+use core::result::Result;
 
 #[derive(Debug)]
 pub enum Error {
     MemoryError,
     RomReadError,
     ComputationError,
+    MissingLayer(&'static str),
 }
 
 impl fmt::Display for Error {
@@ -21,35 +23,36 @@ impl fmt::Display for Error {
             Error::MemoryError => write!(f, "Memory allocation error"),
             Error::RomReadError => write!(f, "ROM read error"),
             Error::ComputationError => write!(f, "Computation error"),
+            Error::MissingLayer(name) => write!(f, "Missing layer: {}", name),
         }
     }
 }
 
-// Constants for model configuration
-const NUM_LAYERS: usize = 6;  // Reduced from standard DistilGPT2
-const HIDDEN_SIZE: usize = 384; // Reduced for memory constraints
-const VOCAB_SIZE: usize = 25000; // Approximate for GPT-2 
 const MAX_SEQ_LENGTH: usize = 128; // Reduced max sequence length
 
 pub struct ModelState<'a> {
     current_layer_weights: Vec<f32>,
-    layer_index: usize,
     hidden_states: Vec<f32>,
     memory_manager: &'a mut MemoryManager,
     last_checkpoint: Option<usize>,
     manifest: &'a manifest::Manifest,
+    dims: crate::model::dims::ModelDims,
+    plan: LayerPlan,
 }
 
 impl<'a> ModelState<'a> {
     pub fn new(memory_manager: &'a mut MemoryManager, manifest: &'a manifest::Manifest) -> Self {
-        let hidden_states = Vec::with_capacity(MAX_SEQ_LENGTH * HIDDEN_SIZE);
+        let dims = manifest.dims;
+        let hidden_states = Vec::with_capacity(MAX_SEQ_LENGTH * dims.d_model as usize);
+        let plan = LayerPlan::from_manifest(manifest);
         ModelState {
             current_layer_weights: Vec::new(),
-            layer_index: 0,
             hidden_states,
             memory_manager,
             last_checkpoint: None,
             manifest,
+            dims,
+            plan,
         }
     }
 
@@ -70,7 +73,6 @@ impl<'a> ModelState<'a> {
 
         self.read_from_rom(offset, size)?;
 
-        self.layer_index = layer_idx;
         Ok(())
     }
 
@@ -81,7 +83,7 @@ impl<'a> ModelState<'a> {
         }
         self.current_layer_weights.clear();
     }
-    
+
     /// Read `size` bytes from ROM at (weights base + offset) using DMA and
     /// convert the bytes into f32 values.
     fn read_from_rom(&mut self, offset: u32, size: usize) -> Result<(), Error> {
@@ -103,70 +105,85 @@ impl<'a> ModelState<'a> {
                 self.current_layer_weights.push(value);
             }
         }
-        
+
         Ok(())
     }
-    
+
     pub fn run_inference(&mut self, input_tokens: &[u32]) -> Result<Vec<u32>, Error> {
-        display::show_progress(0, NUM_LAYERS + 1);
-        self.load_layer_weights(0)?;
+        let total_steps = self.plan.layers.len() + 1;
+        display::show_progress(0, total_steps);
+
+        let embedding_idx = self
+            .plan
+            .embedding
+            .ok_or(Error::MissingLayer(names::L_TOK_EMB))?;
+
+        self.load_layer_weights(embedding_idx)?;
         self.memory_manager.log_usage("embed_load");
         self.apply_embeddings(input_tokens)?;
         self.memory_manager.log_usage("embed_apply");
         self.unload_layer_weights();
         self.memory_manager.log_usage("embed_unload");
 
-        for layer_idx in 0..NUM_LAYERS {
-            self.load_layer_weights(layer_idx * 2 + 1)?;
+        for (idx, pair) in self.plan.layers.iter().enumerate() {
+            self.load_layer_weights(pair.attn_idx)?;
             self.memory_manager.log_usage("attn_load");
             self.apply_attention()?;
             self.memory_manager.log_usage("attn_apply");
             self.unload_layer_weights();
             self.memory_manager.log_usage("attn_unload");
 
-            self.load_layer_weights(layer_idx * 2 + 2)?;
+            self.load_layer_weights(pair.ffn_idx)?;
             self.memory_manager.log_usage("ffn_load");
             self.apply_ffn()?;
             self.memory_manager.log_usage("ffn_apply");
             self.unload_layer_weights();
             self.memory_manager.log_usage("ffn_unload");
 
-            display::show_progress(layer_idx + 1, NUM_LAYERS + 1);
+            display::show_progress(idx + 1, total_steps);
         }
 
-        self.load_layer_weights(NUM_LAYERS * 2 + 1)?;
+        let output_idx = self
+            .plan
+            .output
+            .ok_or(Error::MissingLayer(names::L_LM_HEAD))?;
+
+        self.load_layer_weights(output_idx)?;
         self.memory_manager.log_usage("out_load");
         let output_tokens = self.generate_output()?;
         self.unload_layer_weights();
         self.memory_manager.log_usage("out_unload");
-        display::show_progress(NUM_LAYERS + 1, NUM_LAYERS + 1);
+        display::show_progress(total_steps, total_steps);
         Ok(output_tokens)
     }
-    
+
     fn apply_embeddings(&mut self, input_tokens: &[u32]) -> Result<(), Error> {
         self.hidden_states.clear();
-        
+        let hidden_size = self.dims.d_model as usize;
+        let vocab_size = self.dims.vocab_size as usize;
         for &token in input_tokens {
-            if token as usize >= VOCAB_SIZE {
+            if token as usize >= vocab_size {
                 return Err(Error::ComputationError);
             }
-            
-            let embed_offset = token as usize * HIDDEN_SIZE;
-            if embed_offset + HIDDEN_SIZE > self.current_layer_weights.len() {
+
+            let embed_offset = token as usize * hidden_size;
+            if embed_offset + hidden_size > self.current_layer_weights.len() {
                 return Err(Error::MemoryError);
             }
-            
-            for i in 0..HIDDEN_SIZE {
-                self.hidden_states.push(self.current_layer_weights[embed_offset + i]);
+
+            for i in 0..hidden_size {
+                self.hidden_states
+                    .push(self.current_layer_weights[embed_offset + i]);
             }
         }
-        
+
         Ok(())
     }
-    
+
     fn apply_attention(&mut self) -> Result<(), Error> {
-        let seq_len = self.hidden_states.len() / HIDDEN_SIZE;
-        let mat_size = HIDDEN_SIZE * HIDDEN_SIZE;
+        let hidden_size = self.dims.d_model as usize;
+        let seq_len = self.hidden_states.len() / hidden_size;
+        let mat_size = hidden_size * hidden_size;
 
         // Ensure we have enough weights for a single-head attention layer
         if self.current_layer_weights.len() < mat_size * 4 {
@@ -177,38 +194,38 @@ impl<'a> ModelState<'a> {
         let (k_w, rest) = rest.split_at(mat_size);
         let (v_w, o_w) = rest.split_at(mat_size);
 
-        let mut q = vec![0.0f32; seq_len * HIDDEN_SIZE];
-        let mut k = vec![0.0f32; seq_len * HIDDEN_SIZE];
-        let mut v = vec![0.0f32; seq_len * HIDDEN_SIZE];
+        let mut q = vec![0.0f32; seq_len * hidden_size];
+        let mut k = vec![0.0f32; seq_len * hidden_size];
+        let mut v = vec![0.0f32; seq_len * hidden_size];
 
         // Linear projections for Q, K, V
         for t in 0..seq_len {
-            for h in 0..HIDDEN_SIZE {
+            for h in 0..hidden_size {
                 let mut q_sum = 0.0;
                 let mut k_sum = 0.0;
                 let mut v_sum = 0.0;
-                for i in 0..HIDDEN_SIZE {
-                    let x = self.hidden_states[t * HIDDEN_SIZE + i];
-                    q_sum += x * q_w[h * HIDDEN_SIZE + i];
-                    k_sum += x * k_w[h * HIDDEN_SIZE + i];
-                    v_sum += x * v_w[h * HIDDEN_SIZE + i];
+                for i in 0..hidden_size {
+                    let x = self.hidden_states[t * hidden_size + i];
+                    q_sum += x * q_w[h * hidden_size + i];
+                    k_sum += x * k_w[h * hidden_size + i];
+                    v_sum += x * v_w[h * hidden_size + i];
                 }
-                q[t * HIDDEN_SIZE + h] = q_sum;
-                k[t * HIDDEN_SIZE + h] = k_sum;
-                v[t * HIDDEN_SIZE + h] = v_sum;
+                q[t * hidden_size + h] = q_sum;
+                k[t * hidden_size + h] = k_sum;
+                v[t * hidden_size + h] = v_sum;
             }
         }
 
-        let mut attended = vec![0.0f32; seq_len * HIDDEN_SIZE];
-        let scale = n64_math::sqrt(HIDDEN_SIZE as f32);
+        let mut attended = vec![0.0f32; seq_len * hidden_size];
+        let scale = n64_math::sqrt(hidden_size as f32);
 
         for t in 0..seq_len {
             let mut scores = vec![0.0f32; seq_len];
             let mut sum = 0.0f32;
             for s in 0..seq_len {
                 let mut dot = 0.0;
-                for h in 0..HIDDEN_SIZE {
-                    dot += q[t * HIDDEN_SIZE + h] * k[s * HIDDEN_SIZE + h];
+                for h in 0..hidden_size {
+                    dot += q[t * hidden_size + h] * k[s * hidden_size + h];
                 }
                 let score = n64_math::exp_approx(dot / scale);
                 scores[s] = score;
@@ -217,20 +234,20 @@ impl<'a> ModelState<'a> {
 
             for s in 0..seq_len {
                 let weight = scores[s] / sum;
-                for h in 0..HIDDEN_SIZE {
-                    attended[t * HIDDEN_SIZE + h] += weight * v[s * HIDDEN_SIZE + h];
+                for h in 0..hidden_size {
+                    attended[t * hidden_size + h] += weight * v[s * hidden_size + h];
                 }
             }
         }
 
-        let mut new_states = vec![0.0f32; seq_len * HIDDEN_SIZE];
+        let mut new_states = vec![0.0f32; seq_len * hidden_size];
         for t in 0..seq_len {
-            for h in 0..HIDDEN_SIZE {
+            for h in 0..hidden_size {
                 let mut sum = 0.0;
-                for i in 0..HIDDEN_SIZE {
-                    sum += attended[t * HIDDEN_SIZE + i] * o_w[h * HIDDEN_SIZE + i];
+                for i in 0..hidden_size {
+                    sum += attended[t * hidden_size + i] * o_w[h * hidden_size + i];
                 }
-                new_states[t * HIDDEN_SIZE + h] = sum;
+                new_states[t * hidden_size + h] = sum;
             }
         }
 
@@ -239,8 +256,9 @@ impl<'a> ModelState<'a> {
     }
 
     fn apply_ffn(&mut self) -> Result<(), Error> {
-        let seq_len = self.hidden_states.len() / HIDDEN_SIZE;
-        let mat_size = HIDDEN_SIZE * HIDDEN_SIZE;
+        let hidden_size = self.dims.d_model as usize;
+        let seq_len = self.hidden_states.len() / hidden_size;
+        let mat_size = hidden_size * hidden_size;
 
         if self.current_layer_weights.len() < mat_size * 2 {
             return Err(Error::MemoryError);
@@ -248,54 +266,57 @@ impl<'a> ModelState<'a> {
 
         let (w1, w2) = self.current_layer_weights.split_at(mat_size);
 
-        let mut hidden = vec![0.0f32; seq_len * HIDDEN_SIZE];
+        let mut hidden = vec![0.0f32; seq_len * hidden_size];
         for t in 0..seq_len {
-            for h in 0..HIDDEN_SIZE {
+            for h in 0..hidden_size {
                 let mut sum = 0.0;
-                for i in 0..HIDDEN_SIZE {
-                    sum += self.hidden_states[t * HIDDEN_SIZE + i] * w1[h * HIDDEN_SIZE + i];
+                for i in 0..hidden_size {
+                    sum += self.hidden_states[t * hidden_size + i] * w1[h * hidden_size + i];
                 }
-                hidden[t * HIDDEN_SIZE + h] = if sum > 0.0 { sum } else { 0.0 };
+                hidden[t * hidden_size + h] = if sum > 0.0 { sum } else { 0.0 };
             }
         }
 
-        let mut output = vec![0.0f32; seq_len * HIDDEN_SIZE];
+        let mut output = vec![0.0f32; seq_len * hidden_size];
         for t in 0..seq_len {
-            for h in 0..HIDDEN_SIZE {
+            for h in 0..hidden_size {
                 let mut sum = 0.0;
-                for i in 0..HIDDEN_SIZE {
-                    sum += hidden[t * HIDDEN_SIZE + i] * w2[h * HIDDEN_SIZE + i];
+                for i in 0..hidden_size {
+                    sum += hidden[t * hidden_size + i] * w2[h * hidden_size + i];
                 }
-                output[t * HIDDEN_SIZE + h] = sum;
+                output[t * hidden_size + h] = sum;
             }
         }
 
         self.hidden_states = output;
         Ok(())
     }
-    
+
     fn generate_output(&self) -> Result<Vec<u32>, Error> {
-        let seq_len = self.hidden_states.len() / HIDDEN_SIZE;
+        let hidden_size = self.dims.d_model as usize;
+        let vocab_size = self.dims.vocab_size as usize;
+        let seq_len = self.hidden_states.len() / hidden_size;
         if seq_len == 0 {
             return Err(Error::ComputationError);
         }
-        
-        let last_pos = (seq_len - 1) * HIDDEN_SIZE;
-        let mut logits = Vec::with_capacity(VOCAB_SIZE);
-        
-        for v in 0..VOCAB_SIZE {
+
+        let last_pos = (seq_len - 1) * hidden_size;
+        let mut logits = Vec::with_capacity(vocab_size);
+
+        for v in 0..vocab_size {
             let mut logit = 0.0;
-            for h in 0..HIDDEN_SIZE {
+            for h in 0..hidden_size {
                 if h < self.hidden_states.len() - last_pos {
-                    let weight_idx = v * HIDDEN_SIZE + h;
+                    let weight_idx = v * hidden_size + h;
                     if weight_idx < self.current_layer_weights.len() {
-                        logit += self.hidden_states[last_pos + h] * self.current_layer_weights[weight_idx];
+                        logit += self.hidden_states[last_pos + h]
+                            * self.current_layer_weights[weight_idx];
                     }
                 }
             }
             logits.push(logit);
         }
-        
+
         let mut max_idx = 0;
         let mut max_val = f32::MIN;
         for (i, &logit) in logits.iter().enumerate() {
@@ -304,9 +325,137 @@ impl<'a> ModelState<'a> {
                 max_idx = i;
             }
         }
-        
+
         Ok(vec![max_idx as u32])
     }
+}
+
+struct LayerPair {
+    attn_idx: usize,
+    ffn_idx: usize,
+}
+
+struct LayerPlan {
+    embedding: Option<usize>,
+    output: Option<usize>,
+    layers: Vec<LayerPair>,
+}
+
+impl LayerPlan {
+    fn from_manifest(manifest: &manifest::Manifest) -> Self {
+        let mut embedding = None;
+        let mut output = None;
+        let mut attn: Vec<(usize, usize)> = Vec::new();
+        let mut ffn: Vec<(usize, usize)> = Vec::new();
+        let mut attn_fallback = 0usize;
+        let mut ffn_fallback = 0usize;
+
+        for (idx, layer) in manifest.layers.iter().enumerate() {
+            let name = layer.name.as_str();
+            if embedding.is_none() && is_embedding_layer(name) {
+                embedding = Some(idx);
+                continue;
+            }
+            if output.is_none() && is_output_layer(name) {
+                output = Some(idx);
+                continue;
+            }
+            if is_attention_layer(name) {
+                let order = parse_layer_index(name).unwrap_or_else(|| {
+                    let v = fallback_order(attn_fallback);
+                    attn_fallback += 1;
+                    v
+                });
+                attn.push((order, idx));
+                continue;
+            }
+            if is_ffn_layer(name) {
+                let order = parse_layer_index(name).unwrap_or_else(|| {
+                    let v = fallback_order(ffn_fallback);
+                    ffn_fallback += 1;
+                    v
+                });
+                ffn.push((order, idx));
+            }
+        }
+
+        attn.sort_by_key(|(order, _)| *order);
+        ffn.sort_by_key(|(order, _)| *order);
+        let mut layers = Vec::new();
+        for (a, f) in attn.into_iter().zip(ffn.into_iter()) {
+            layers.push(LayerPair {
+                attn_idx: a.1,
+                ffn_idx: f.1,
+            });
+        }
+
+        LayerPlan {
+            embedding,
+            output,
+            layers,
+        }
+    }
+}
+
+fn fallback_order(fallback: usize) -> usize {
+    0x1000 + fallback
+}
+
+fn is_embedding_layer(name: &str) -> bool {
+    name == names::L_TOK_EMB || name.contains("tok_emb")
+}
+
+fn is_output_layer(name: &str) -> bool {
+    name == names::L_LM_HEAD || name.ends_with("lm_head")
+}
+
+fn is_attention_layer(name: &str) -> bool {
+    name.contains("attn") || name.contains("attention")
+}
+
+fn is_ffn_layer(name: &str) -> bool {
+    name.contains("ffn") || name.contains("mlp") || name.contains("feed_forward")
+}
+
+fn parse_layer_index(name: &str) -> Option<usize> {
+    if let Some(pos) = name.find(".h.") {
+        let mut value: usize = 0;
+        let mut found = false;
+        for ch in name[pos + 3..].chars() {
+            if ch.is_ascii_digit() {
+                found = true;
+                value = value * 10 + (ch as u8 - b'0') as usize;
+            } else {
+                break;
+            }
+        }
+        if found {
+            return Some(value);
+        }
+    }
+    if let Some(pos) = name.find("layer") {
+        let mut idx = pos + 5;
+        let bytes = name.as_bytes();
+        if idx < bytes.len() && (bytes[idx] == b'_' || bytes[idx] == b'.') {
+            idx += 1;
+        }
+        let mut value: usize = 0;
+        let mut found = false;
+        while idx < bytes.len() {
+            let b = bytes[idx];
+            if b.is_ascii_digit() {
+                found = true;
+                value = value * 10 + (b - b'0') as usize;
+                idx += 1;
+            } else {
+                break;
+            }
+        }
+        if found {
+            return Some(value);
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -319,8 +468,12 @@ mod tests {
 
     #[test]
     fn load_layer_out_of_bounds() {
-        let mut mm = MemoryManager::new();
-        let manifest = manifest::Manifest { layers: vec![] };
+        let mut mm = MemoryManager::new_for_test();
+        let manifest = manifest::Manifest {
+            layers: vec![],
+            align: 64,
+            dims: crate::model::dims::ModelDims::new(16, 32),
+        };
         let mut state = ModelState::new(&mut mm, &manifest);
         let res = state.load_layer_weights(0);
         assert!(matches!(res, Err(Error::MemoryError)));
@@ -328,18 +481,30 @@ mod tests {
 
     #[test]
     fn apply_embeddings_invalid_token() {
-        let mut mm = MemoryManager::new();
-        let manifest = manifest::Manifest { layers: vec![manifest::Layer { name: String::new(), offset: 0, size: (HIDDEN_SIZE * 4) as u32 }] };
+        let mut mm = MemoryManager::new_for_test();
+        let manifest = manifest::Manifest {
+            layers: vec![manifest::Layer {
+                name: names::L_TOK_EMB.to_string(),
+                offset: 0,
+                size: 64,
+            }],
+            align: 64,
+            dims: crate::model::dims::ModelDims::new(16, 32),
+        };
         let mut state = ModelState::new(&mut mm, &manifest);
-        state.current_layer_weights = vec![0.0; HIDDEN_SIZE];
-        let res = state.apply_embeddings(&[VOCAB_SIZE as u32]);
+        state.current_layer_weights = vec![0.0; 16];
+        let res = state.apply_embeddings(&[manifest.dims.vocab_size]);
         assert!(matches!(res, Err(Error::ComputationError)));
     }
 
     #[test]
     fn generate_output_empty_state() {
-        let mut mm = MemoryManager::new();
-        let manifest = manifest::Manifest { layers: vec![] };
+        let mut mm = MemoryManager::new_for_test();
+        let manifest = manifest::Manifest {
+            layers: vec![],
+            align: 64,
+            dims: crate::model::dims::ModelDims::new(16, 32),
+        };
         let state = ModelState::new(&mut mm, &manifest);
         let res = state.generate_output();
         assert!(matches!(res, Err(Error::ComputationError)));

--- a/n64llm/n64-rust/src/main.rs
+++ b/n64llm/n64-rust/src/main.rs
@@ -18,15 +18,15 @@ use core::panic::PanicInfo;
 
 mod diag;
 mod display;
+mod infer;
 mod inference_engine;
 mod io;
 mod manifest;
 mod memory_manager;
 mod model;
+mod stream;
 mod tokenizer;
 mod util;
-mod infer;
-mod stream;
 
 #[no_mangle]
 pub extern "C" fn main() -> ! {
@@ -53,6 +53,10 @@ pub extern "C" fn main() -> ! {
 
     let manifest = manifest::load();
     display::print_line(&format!("Manifest layers: {}", manifest.layers.len()));
+    display::print_line(&format!(
+        "Model dims: d_model={} vocab={}",
+        manifest.dims.d_model, manifest.dims.vocab_size
+    ));
 
     // Initialize memory management system.
     let mut memory = unsafe { memory_manager::init() };
@@ -112,7 +116,15 @@ pub extern "C" fn main() -> ! {
 }
 
 fn wait_for_start_button() {
-    // Controller polling not implemented; placeholder for hardware pause.
+    display::print_line("Press START to continue...");
+    loop {
+        let data = unsafe { n64_sys::read_controller(n64_sys::CONTROLLER_1) };
+        if (data.buttons & n64_sys::START_BUTTON) != 0 {
+            break;
+        }
+        delay(1000);
+    }
+    display::print_line("Start detected. Continuing...");
 }
 
 fn delay(ms: u32) {

--- a/n64llm/n64-rust/src/n64_sys.rs
+++ b/n64llm/n64-rust/src/n64_sys.rs
@@ -1,7 +1,6 @@
 // n64_sys.rs
 // System definitions for Nintendo 64 hardware
 
-
 // PI (Peripheral Interface) Registers
 pub const PI_BASE_REG: usize = 0xA4600000;
 pub const PI_DRAM_ADDR_REG: usize = 0xA4600000;
@@ -52,6 +51,10 @@ pub const SI_DRAM_ADDR_REG: usize = 0xA4800000;
 pub const SI_PIF_ADDR_RD64B_REG: usize = 0xA4800004;
 pub const SI_PIF_ADDR_WR64B_REG: usize = 0xA4800010;
 pub const SI_STATUS_REG: usize = 0xA4800018;
+pub const SI_STATUS_DMA_BUSY: u32 = 0x0001;
+pub const SI_STATUS_IO_BUSY: u32 = 0x0002;
+
+const PIF_RAM_ADDR: u32 = 0x1FC007C0;
 
 // Memory map
 pub const RDRAM_BASE: usize = 0x80000000;
@@ -92,23 +95,97 @@ pub const C_RIGHT: u16 = 0x0001;
 pub unsafe fn pi_read(ram_address: *mut u8, rom_address: u32, length: u32) {
     // Wait for any previous DMA to complete
     while (*(PI_STATUS_REG as *const u32) & PI_STATUS_DMA_BUSY) != 0 {}
-    
+
     // Set up DMA
     *(PI_DRAM_ADDR_REG as *mut u32) = ram_address as u32;
     *(PI_CART_ADDR_REG as *mut u32) = rom_address;
     *(PI_RD_LEN_REG as *mut u32) = length - 1;
-    
+
     // Wait for DMA to complete
     while (*(PI_STATUS_REG as *const u32) & PI_STATUS_DMA_BUSY) != 0 {}
 }
 
 // Read controller data
-pub unsafe fn read_controller(_controller: usize) -> ControllerData {
-    // In a real implementation, this would read from the controller
-    // For now, return a placeholder
+#[repr(align(64))]
+struct JoybusBlock([u8; 64]);
+
+static mut JOYBUS_TX: JoybusBlock = JoybusBlock([0; 64]);
+static mut JOYBUS_RX: JoybusBlock = JoybusBlock([0; 64]);
+
+const READ_CONTROLLER_BLOCK: [u8; 64] = [
+    0xFF, 0x01, 0x04, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x04, 0x01, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0x01, 0x04, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x04, 0x01, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+];
+
+fn to_kseg1(ptr: *mut u8) -> *mut u8 {
+    ((ptr as usize) | 0xA000_0000) as *mut u8
+}
+
+unsafe fn joybus_exec(cmd: &[u8; 64], out: &mut [u8; 64]) {
+    let status = SI_STATUS_REG as *const u32;
+
+    while (*status & (SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY)) != 0 {}
+
+    let tx_ptr = to_kseg1(JOYBUS_TX.0.as_mut_ptr());
+    for (i, byte) in cmd.iter().enumerate() {
+        core::ptr::write_volatile(tx_ptr.add(i), *byte);
+    }
+
+    *(SI_DRAM_ADDR_REG as *mut u32) = JOYBUS_TX.0.as_ptr() as u32;
+    *(SI_PIF_ADDR_WR64B_REG as *mut u32) = PIF_RAM_ADDR;
+
+    while (*status & (SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY)) != 0 {}
+
+    *(SI_DRAM_ADDR_REG as *mut u32) = JOYBUS_RX.0.as_mut_ptr() as u32;
+    *(SI_PIF_ADDR_RD64B_REG as *mut u32) = PIF_RAM_ADDR;
+
+    while (*status & (SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY)) != 0 {}
+
+    let rx_ptr = to_kseg1(JOYBUS_RX.0.as_mut_ptr());
+    for i in 0..64 {
+        out[i] = core::ptr::read_volatile(rx_ptr.add(i));
+    }
+}
+
+pub unsafe fn read_controller(controller: usize) -> ControllerData {
+    if controller > 3 {
+        return ControllerData {
+            buttons: 0,
+            stick_x: 0,
+            stick_y: 0,
+        };
+    }
+
+    let mut raw = [0u8; 64];
+    joybus_exec(&READ_CONTROLLER_BLOCK, &mut raw);
+
+    let base = controller * 8;
+    if base + 7 >= raw.len() {
+        return ControllerData {
+            buttons: 0,
+            stick_x: 0,
+            stick_y: 0,
+        };
+    }
+
+    let status = raw[base];
+    if status == 0xFF {
+        return ControllerData {
+            buttons: 0,
+            stick_x: 0,
+            stick_y: 0,
+        };
+    }
+
+    let buttons = ((raw[base + 4] as u16) << 8) | raw[base + 5] as u16;
+    let stick_x = raw[base + 6] as i8;
+    let stick_y = raw[base + 7] as i8;
+
     ControllerData {
-        buttons: 0,
-        stick_x: 0,
-        stick_y: 0,
+        buttons,
+        stick_x,
+        stick_y,
     }
 }

--- a/n64llm/n64-rust/src/weights_manifest.rs
+++ b/n64llm/n64-rust/src/weights_manifest.rs
@@ -3,21 +3,28 @@
 #[cfg(feature = "embed_assets")]
 #[link_section = ".model_manifest"]
 #[used]
-pub static MODEL_MANIFEST: [u8; { include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"),
-    "/assets/weights.manifest.bin")).len() }] =
-    *include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/weights.manifest.bin"));
+pub static MODEL_MANIFEST: [u8; {
+    include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/weights.manifest.bin"
+    ))
+    .len()
+}] = *include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/assets/weights.manifest.bin"
+));
 
-#[cfg(any(test, feature = "host"))]
+#[cfg(not(feature = "embed_assets"))]
 extern crate alloc;
-#[cfg(any(test, feature = "host"))]
-use alloc::vec::Vec;
-#[cfg(any(test, feature = "host"))]
+#[cfg(not(feature = "embed_assets"))]
 use alloc::boxed::Box;
+#[cfg(not(feature = "embed_assets"))]
+use alloc::vec::Vec;
 
-#[cfg(any(test, feature = "host"))]
+#[cfg(not(feature = "embed_assets"))]
 use core::sync::atomic::{AtomicPtr, Ordering};
 
-#[cfg(any(test, feature = "host"))]
+#[cfg(not(feature = "embed_assets"))]
 fn man_bytes_host() -> &'static [u8] {
     // Tiny v2 manifest with 2 entries; used only in unit tests if assets are absent.
     // (Constructed once; static for lifetime)
@@ -26,9 +33,9 @@ fn man_bytes_host() -> &'static [u8] {
         if P.load(Ordering::Relaxed).is_null() {
             let mut v = Vec::<u8>::new();
             v.extend_from_slice(b"N64W");
-            v.extend_from_slice(&2u16.to_le_bytes());        // ver=2
-            v.extend_from_slice(&64u16.to_le_bytes());       // align
-            v.extend_from_slice(&2u32.to_le_bytes());        // count
+            v.extend_from_slice(&2u16.to_le_bytes()); // ver=2
+            v.extend_from_slice(&64u16.to_le_bytes()); // align
+            v.extend_from_slice(&2u32.to_le_bytes()); // count
             let push = |v: &mut Vec<u8>, name: &str, off: u32, sz: u32, crc: u32| {
                 let nb = name.as_bytes();
                 v.extend_from_slice(&(nb.len() as u16).to_le_bytes());
@@ -37,14 +44,14 @@ fn man_bytes_host() -> &'static [u8] {
                 v.extend_from_slice(&sz.to_le_bytes());
                 v.extend_from_slice(&crc.to_le_bytes());
             };
-            push(&mut v, "tok", 64, 16, 0x4D6F28D3);
-            push(&mut v, "ffn", 128, 4, 0xD202EF8D);
+            push(&mut v, "tok_embeddings", 64, 16, 0);
+            push(&mut v, "lm_head", 128, 4, 0);
             let b = v.into_boxed_slice();
             let p = Box::into_raw(b) as *mut u8;
             P.store(p, Ordering::Relaxed);
         }
         let p = P.load(Ordering::Relaxed);
-        core::slice::from_raw_parts(p, 4 + 2 + 2 + 4 + (2 + 3 + 4 + 4 + 4)*2)
+        core::slice::from_raw_parts(p, 4 + 2 + 2 + 4 + (2 + 3 + 4 + 4 + 4) * 2)
     }
 }
 
@@ -65,48 +72,95 @@ pub struct ManifestView<'a> {
 }
 
 #[derive(Debug)]
-pub enum ManErr { BadMagic, BadVersion, Truncated, Utf8 }
+pub enum ManErr {
+    BadMagic,
+    BadVersion,
+    Truncated,
+    Utf8,
+}
 
 fn rd_u16_le(b: &[u8], i: &mut usize) -> Result<u16, ManErr> {
-    if *i + 2 > b.len() { return Err(ManErr::Truncated); }
-    let v = u16::from_le_bytes([b[*i], b[*i+1]]); *i += 2; Ok(v)
+    if *i + 2 > b.len() {
+        return Err(ManErr::Truncated);
+    }
+    let v = u16::from_le_bytes([b[*i], b[*i + 1]]);
+    *i += 2;
+    Ok(v)
 }
 fn rd_u32_le(b: &[u8], i: &mut usize) -> Result<u32, ManErr> {
-    if *i + 4 > b.len() { return Err(ManErr::Truncated); }
-    let v = u32::from_le_bytes([b[*i], b[*i+1], b[*i+2], b[*i+3]]); *i += 4; Ok(v)
+    if *i + 4 > b.len() {
+        return Err(ManErr::Truncated);
+    }
+    let v = u32::from_le_bytes([b[*i], b[*i + 1], b[*i + 2], b[*i + 3]]);
+    *i += 4;
+    Ok(v)
 }
 
 impl<'a> ManifestView<'a> {
     pub fn new(bytes: &'a [u8]) -> Result<Self, ManErr> {
-        if bytes.len() < 12 { return Err(ManErr::Truncated); }
-        if &bytes[0..4] != b"N64W" { return Err(ManErr::BadMagic); }
+        if bytes.len() < 12 {
+            return Err(ManErr::Truncated);
+        }
+        if &bytes[0..4] != b"N64W" {
+            return Err(ManErr::BadMagic);
+        }
         let mut i = 4;
         let ver = rd_u16_le(bytes, &mut i)?;
-        if ver != 1 && ver != 2 { return Err(ManErr::BadVersion); }
+        if ver != 1 && ver != 2 {
+            return Err(ManErr::BadVersion);
+        }
         let align = rd_u16_le(bytes, &mut i)?;
         let count = rd_u32_le(bytes, &mut i)?;
-        Ok(Self { bytes, align, count, off_entries: i, ver })
+        Ok(Self {
+            bytes,
+            align,
+            count,
+            off_entries: i,
+            ver,
+        })
     }
-    pub fn align(&self) -> u16 { self.align }
-    pub fn count(&self) -> u32 { self.count }
-    pub fn version(&self) -> u16 { self.ver }
+    pub fn align(&self) -> u16 {
+        self.align
+    }
+    pub fn count(&self) -> u32 {
+        self.count
+    }
+    pub fn version(&self) -> u16 {
+        self.ver
+    }
 
     pub fn for_each<F: FnMut(Entry<'a>) -> bool>(&self, mut f: F) -> Result<(), ManErr> {
         let mut i = self.off_entries;
         for _ in 0..self.count {
             let nlen = rd_u16_le(self.bytes, &mut i)? as usize;
-            if i + nlen + 8 > self.bytes.len() { return Err(ManErr::Truncated); }
-            let name_bytes = &self.bytes[i..i+nlen]; i += nlen;
-            let off = u32::from_le_bytes(self.bytes[i..i+4].try_into().unwrap()); i += 4;
-            let sz  = u32::from_le_bytes(self.bytes[i..i+4].try_into().unwrap()); i += 4;
+            if i + nlen + 8 > self.bytes.len() {
+                return Err(ManErr::Truncated);
+            }
+            let name_bytes = &self.bytes[i..i + nlen];
+            i += nlen;
+            let off = u32::from_le_bytes(self.bytes[i..i + 4].try_into().unwrap());
+            i += 4;
+            let sz = u32::from_le_bytes(self.bytes[i..i + 4].try_into().unwrap());
+            i += 4;
             let crc32 = if self.ver >= 2 {
-                if i + 4 > self.bytes.len() { return Err(ManErr::Truncated); }
-                let c = u32::from_le_bytes(self.bytes[i..i+4].try_into().unwrap()); i += 4; Some(c)
+                if i + 4 > self.bytes.len() {
+                    return Err(ManErr::Truncated);
+                }
+                let c = u32::from_le_bytes(self.bytes[i..i + 4].try_into().unwrap());
+                i += 4;
+                Some(c)
             } else {
                 None
             };
             let name = core::str::from_utf8(name_bytes).map_err(|_| ManErr::Utf8)?;
-            if !f(Entry { name, offset: off, size: sz, crc32 }) { break; }
+            if !f(Entry {
+                name,
+                offset: off,
+                size: sz,
+                crc32,
+            }) {
+                break;
+            }
         }
         Ok(())
     }
@@ -131,15 +185,19 @@ mod t_manifest {
     fn parses_v1_and_v2() {
         // v1 blob
         let mut v1 = b"N64W".to_vec();
-        v1.extend(&1u16.to_le_bytes()); v1.extend(&64u16.to_le_bytes());
+        v1.extend(&1u16.to_le_bytes());
+        v1.extend(&64u16.to_le_bytes());
         v1.extend(&1u32.to_le_bytes());
-        v1.extend(&1u16.to_le_bytes()); v1.extend(b"a");
-        v1.extend(&64u32.to_le_bytes()); v1.extend(&3u32.to_le_bytes());
+        v1.extend(&1u16.to_le_bytes());
+        v1.extend(b"a");
+        v1.extend(&64u32.to_le_bytes());
+        v1.extend(&3u32.to_le_bytes());
         let m1 = ManifestView::new(&v1).unwrap();
         assert_eq!(m1.version(), 1);
 
         // v2 blob = v1 + crc
-        let mut v2 = v1.clone(); v2[4] = 2; // version=2
+        let mut v2 = v1.clone();
+        v2[4] = 2; // version=2
         v2.extend(&0xDEADBEEFu32.to_le_bytes());
         let m2 = ManifestView::new(&v2).unwrap();
         assert_eq!(m2.version(), 2);


### PR DESCRIPTION
## Summary
- share a single global bump arena across the allocator API and expose testing helpers
- add Joybus-based controller reads, block on START before inference, and print model dims from the manifest
- drive the inference engine from manifest metadata and layer names, include a deterministic tokenizer fallback, and adjust the weights manifest stub

## Testing
- cargo test --manifest-path n64llm/n64-rust/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68c90833dedc83239e1b88fd685d2052