### PR TITLE
Ensure ROM builds embed assets

### DIFF
--- a/scripts/export_and_test.sh
+++ b/scripts/export_and_test.sh
@@ -15,7 +15,7 @@ python tools/validate_weights.py \
   --man n64llm/n64-rust/assets/weights.manifest.bin --crc
 
 # 2) Build ROM (nightly) with build-std only here
-( cd n64llm/n64-rust && cargo +nightly -Z build-std=core,alloc n64 build --profile release )
+ ( cd n64llm/n64-rust && cargo +nightly -Z build-std=core,alloc n64 build --profile release --features embed_assets )
 
 # 3) Optional emu smoke (never moves binaries; asks where to place)
 ./scripts/emu_smoke.sh || true


### PR DESCRIPTION
## Summary
- update export_and_test automation script to pass the embed_assets feature when invoking the N64 build so the ROM links bundled weights

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9a4f6b4e48323b5dde71fa1b2dca3