### PR TITLE
Ensure ROM builds include embedded assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ A custom toolchain is required. Build with nightly and package the resulting ELF
 
 ```bash
 cd n64llm/n64-rust
-cargo +nightly -Z build-std=core,alloc n64 build --profile release
+cargo +nightly -Z build-std=core,alloc n64 build --profile release --features embed_assets
 ```
+
+The `embed_assets` feature bundles the manifest and weights into the ROM image.
 
 This produces a bootable Nintendo&nbsp;64 ROM named `n64_gpt.z64` in the current
 directory. The linker and configuration reserve up to roughly 1&nbsp;GiB of cart

--- a/codex.md
+++ b/codex.md
@@ -18,7 +18,9 @@ After these tools are installed, build the Rust project with:
 
 ```bash
 cd n64llm/n64-rust
-cargo +nightly-2022-06-21 n64 build --profile release
+cargo +nightly-2022-06-21 n64 build --profile release --features embed_assets
 ```
+
+Enabling the `embed_assets` feature ensures the ROM includes the exported weights and manifest files.
 
 This produces a bootable ROM under `target/n64/release/` which can be run in an emulator such as `mupen64plus`.

--- a/scripts/emu_smoke.sh
+++ b/scripts/emu_smoke.sh
@@ -7,7 +7,7 @@ ASSETS="n64llm/n64-rust/assets"
 [[ -f "$ASSETS/weights.manifest.bin" ]] || { echo "Joshua: please move your manifest to $ASSETS/weights.manifest.bin"; exit 1; }
 
 # 1) Build (no moving binaries).
-PACK_ROM=1 cargo build --release
+PACK_ROM=1 cargo build --release --features embed_assets
 
 # 2) Find the produced ROM and run emulator if available.
 ROM="$(ls -1 target/**/release/*.z64 2>/dev/null | head -n1 || true)"

--- a/scripts/export_smoke_and_clean.sh
+++ b/scripts/export_smoke_and_clean.sh
@@ -11,7 +11,7 @@ if [[ "$MODE" == "real" ]]; then
   # Example: keep last 8 blocks of gpt2-medium as fp16 (tweak as needed)
   python tools/export_gpt2_n64.py --model gpt2-medium --dtype fp16 --keep-layers 8 --out-dir "$ASSETS"
 else
-  python tools/make_debug_weights.py --out-dir "$ASSETS" --chunks 8 --chunkKB 64
+  python tools/make_debug_weights.py --out-bin "$BIN" --out-man "$MAN"
 fi
 
 # 1) Validate


### PR DESCRIPTION
## Summary
- update the build instructions and helper scripts to always enable the `embed_assets` feature
- document why the feature flag is required so released ROMs include the weights
- fix export_smoke_and_clean.sh so the debug-weight helper receives the arguments it expects

## Testing
- RUN_SMOKE=0 scripts/export_smoke_and_clean.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9a5efefc08323892ef7c51d07b8b8