### PR TITLE
Lock exporter workflow to canonical script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ The following environment variables control the exporter:
 - `N64_SOUL_KEEP_LAYERS` – keep only the last N transformer blocks.
 - `N64_SOUL_TUNE_CONFIG` – optional JSON file archived with the export.
 - `N64_SOUL_SKIP_EXPORT` – set to `1` to reuse the assets already on disk.
-- `N64_SOUL_EXPORT_SCRIPT` – point at an alternative exporter if needed.
+
+The build script always invokes `tools/export_gpt2_n64.py`. Adjust that script
+directly if you need to change export behavior; keeping a single exporter avoids
+stale artifacts from earlier experiments.
 
 Nintendo 64 ROMs also require the CIC-6102 boot code. Because that blob is
 copyrighted we cannot ship it; you must provide your own dump via

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
 - [x] Confirm ROM layout and address mapping in `n64.ld` for `.model_weights`.
-- [x] Validate `weights.bin` against `weights.manifest.json` using `tools/validate_weights.py`.
+- [x] Validate `weights.bin` against `weights.manifest.bin` using `tools/validate_weights.py`.
 - [x] Implement efficient layer streaming with checkpoints in `memory_manager.rs`.
 - [x] Replace placeholder attention and FFN code with real transformer operations.
 - [x] Complete tokenizer and controller input logic in `tokenizer.rs` and `display.rs`.

--- a/n64llm/n64-rust/build.rs
+++ b/n64llm/n64-rust/build.rs
@@ -21,7 +21,6 @@ fn main() {
     println!("cargo:rerun-if-env-changed=N64_SOUL_DTYPE");
     println!("cargo:rerun-if-env-changed=N64_SOUL_KEEP_LAYERS");
     println!("cargo:rerun-if-env-changed=N64_SOUL_TUNE_CONFIG");
-    println!("cargo:rerun-if-env-changed=N64_SOUL_EXPORT_SCRIPT");
     println!("cargo:rerun-if-env-changed=PYTHON");
 
     if env::var_os("CARGO_FEATURE_EMBED_ASSETS").is_none() {
@@ -44,9 +43,7 @@ fn main() {
         .map(PathBuf::from)
         .unwrap_or_else(|| manifest_dir.clone());
 
-    let script_path = env::var("N64_SOUL_EXPORT_SCRIPT")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| repo_root.join("tools").join("export_gpt2_n64.py"));
+    let script_path = repo_root.join("tools").join("export_gpt2_n64.py");
 
     if !script_path.exists() {
         panic!("export script not found at {}", script_path.display());


### PR DESCRIPTION
## Summary
- lock the build script to always invoke `tools/export_gpt2_n64.py`
- document the canonical exporter path and fix the TODO manifest reference

## Testing
- cargo test --lib --features host
- cargo test --test host_sanity --features host

------
https://chatgpt.com/codex/tasks/task_e_68ca07c1fb0c83239f580103797fd1dd