### PR TITLE
Fix export script for cargo-n64 CLI change

### DIFF
--- a/scripts/export_and_test.sh
+++ b/scripts/export_and_test.sh
@@ -44,7 +44,7 @@ fi
 # Build the ROM. The build script exports and validates fresh weights.
 (
   cd "$ROM_DIR" && \
-  cargo +nightly -Z build-std=core,alloc n64 build --profile release --features embed_assets
+  cargo +nightly -Z build-std=core,alloc n64 build --release --features embed_assets
 )
 
 # Confirm the assets exist for downstream tooling.


### PR DESCRIPTION
## Summary
- update the export script to use `--release` with `cargo n64 build` so it works with current cargo-n64 CLI

## Testing
- not run (toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca0c9cb1208323a18a5c91b2ab232d