### PR TITLE
Document pinned nightly toolchain for N64 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,21 @@ repository.
 ## Environment setup
 
 Install the Rust toolchain and helper utilities. See
-[docs/setup.md](docs/setup.md) for more detail.
+[docs/setup.md](docs/setup.md) for more detail. The project is pinned to the
+`nightly-2022-06-21` toolchain because newer nightlies no longer ship the
+`mips-nintendo64-none` target:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup toolchain install nightly --component rust-src
-rustup target add mips-nintendo64-none --toolchain nightly
+export N64SOUL_TOOLCHAIN=nightly-2022-06-21
+
+rustup toolchain install "$N64SOUL_TOOLCHAIN"
+rustup component add rust-src --toolchain "$N64SOUL_TOOLCHAIN"
+rustup target add mips-nintendo64-none --toolchain "$N64SOUL_TOOLCHAIN"
 
 # Install a patched cargo-n64; upstream 0.2.0 relies on the removed
 # `Error::backtrace` API and fails to build on current compilers.
-bash tools/install_cargo_n64.sh
+N64SOUL_TOOLCHAIN="$N64SOUL_TOOLCHAIN" bash tools/install_cargo_n64.sh
 
 cargo install nust64
 ```
@@ -62,8 +67,7 @@ below. Use `python tools/check_python_deps.py` to confirm the Python
 dependencies for the export pipeline are present before running any of the
 scripts.
 
-> **Note:** `tools/install_cargo_n64.sh` first attempts a stock `cargo +nightly
-> install cargo-n64`. If that fails it clones the upstream repository, applies a
+> **Note:** `tools/install_cargo_n64.sh` first attempts a stock `cargo +"$N64SOUL_TOOLCHAIN" install cargo-n64`. If that fails it clones the upstream repository, applies a
 > small shim that disables the `backtrace` call, and installs the patched
 > version. Re-running the script is idempotent.
 
@@ -81,7 +85,8 @@ export N64_SOUL_MODEL_ID=distilgpt2
 export N64_SOUL_DTYPE=fp16
 export N64_SOUL_KEEP_LAYERS=8
 
-cargo +nightly -Z build-std=core,alloc n64 build --profile release --features embed_assets
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
+cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --profile release --features embed_assets
 ```
 
 Unset `N64_SOUL_KEEP_LAYERS` (or skip exporting entirely) to use the full model.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,17 +12,27 @@ Install Rust using [`rustup`](https://rustup.rs/) if it is not already available
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Then add the Nintendo 64 target and install the helper subcommand:
+Then add the Nintendo 64 target and install the helper subcommand. The
+`mips-nintendo64-none` target disappeared from recent nightlies, so the build
+expects the pinned toolchain `nightly-2022-06-21`. Export the toolchain once so
+the helper scripts and docs remain in sync:
 
 ```bash
-rustup toolchain install nightly --component rust-src
-rustup target add mips-nintendo64-none --toolchain nightly
-bash tools/install_cargo_n64.sh
+export N64SOUL_TOOLCHAIN=nightly-2022-06-21
+
+rustup toolchain install "$N64SOUL_TOOLCHAIN"
+rustup component add rust-src --toolchain "$N64SOUL_TOOLCHAIN"
+rustup target add mips-nintendo64-none --toolchain "$N64SOUL_TOOLCHAIN"
+
+# Install cargo-n64 with the pinned toolchain.
+N64SOUL_TOOLCHAIN="$N64SOUL_TOOLCHAIN" bash tools/install_cargo_n64.sh
+
+# Optional utilities can use stable.
 cargo install nust64
 ```
 
 The `tools/install_cargo_n64.sh` script first attempts a stock
-`cargo +nightly install cargo-n64`. If that fails it clones upstream,
+`cargo +"$N64SOUL_TOOLCHAIN" install cargo-n64`. If that fails it clones upstream,
 patches the offending dependency, and reinstalls the tool in-place.
 Re-running the script is idempotent.
 

--- a/scripts/emu_smoke.sh
+++ b/scripts/emu_smoke.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROM_DIR="$ROOT_DIR/n64llm/n64-rust"
 ASSETS="$ROM_DIR/assets"
 ROM_GLOB="$ROM_DIR/target"/n64/release/*.z64
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
 
 cd "$ROOT_DIR"
 
@@ -16,7 +17,7 @@ if [[ -z "$ROM_PATH" ]]; then
   echo "No ROM found; rebuilding with existing assets."
   (
     cd "$ROM_DIR" && \
-    N64_SOUL_SKIP_EXPORT=1 cargo +nightly -Z build-std=core,alloc n64 build --profile release --features embed_assets
+    N64_SOUL_SKIP_EXPORT=1 cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --profile release --features embed_assets
   )
   ROM_PATH=$(ls -1 $ROM_GLOB 2>/dev/null | head -n1 || true)
 fi

--- a/scripts/export_and_test.sh
+++ b/scripts/export_and_test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROM_DIR="$ROOT_DIR/n64llm/n64-rust"
 ASSETS_DIR="$ROM_DIR/assets"
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
 
 cd "$ROOT_DIR"
 
@@ -44,7 +45,7 @@ fi
 # Build the ROM. The build script exports and validates fresh weights.
 (
   cd "$ROM_DIR" && \
-  cargo +nightly -Z build-std=core,alloc n64 build --release --features embed_assets
+  cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --release --features embed_assets
 )
 
 # Confirm the assets exist for downstream tooling.

--- a/tools/install_cargo_n64.sh
+++ b/tools/install_cargo_n64.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 REPO="https://github.com/rust-console/cargo-n64"
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
 
 echo "[cargo-n64] Trying upstream main first…"
-if cargo +nightly install cargo-n64 --git "$REPO" --branch main --locked; then
+if cargo +"$TOOLCHAIN" install cargo-n64 --git "$REPO" --branch main --locked; then
   echo "[cargo-n64] Installed from upstream main."
   exit 0
 fi
@@ -22,6 +23,6 @@ sed -i '/^\s*#!\[feature(backtrace)\]\s*$/d' src/lib.rs || true
 perl -0777 -pe 's/error\s*\.\s*backtrace\s*\(\s*\)/None::<&std::backtrace::Backtrace>/g' -i src/lib.rs
 
 # Install the patched tool
-cargo +nightly install --path . --locked
+cargo +"$TOOLCHAIN" install --path . --locked
 popd >/dev/null
 echo "[cargo-n64] Installed from patched tree."


### PR DESCRIPTION
## Summary
- clarify in the README and setup docs that the project depends on nightly-2022-06-21 and show how to export `N64SOUL_TOOLCHAIN`
- update build/test helper scripts to respect `N64SOUL_TOOLCHAIN` when invoking `cargo`
- run the cargo-n64 installer with the pinned toolchain by default

## Testing
- not run (toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca360892248323b71011afbb2745fd