### PR TITLE
Document workaround for missing mips-nintendo64 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ export N64SOUL_TOOLCHAIN=nightly-2022-06-21
 
 rustup toolchain install "$N64SOUL_TOOLCHAIN"
 rustup component add rust-src --toolchain "$N64SOUL_TOOLCHAIN"
-rustup target add mips-nintendo64-none --toolchain "$N64SOUL_TOOLCHAIN"
 
 # Install a patched cargo-n64; upstream 0.2.0 relies on the removed
 # `Error::backtrace` API and fails to build on current compilers.
@@ -61,6 +60,12 @@ N64SOUL_TOOLCHAIN="$N64SOUL_TOOLCHAIN" bash tools/install_cargo_n64.sh
 
 cargo install nust64
 ```
+
+Rustup no longer publishes a `mips-nintendo64-none` standard library, so running
+`rustup target add` now reports `toolchain 'nightly-2022-06-21-…' does not
+support target`. That failure is expected—`cargo-n64` provides the target
+specification and the build uses `-Zbuild-std=core,alloc` to compile `core` and
+`alloc` from the `rust-src` component.
 
 After installing these tools you can build and run the project as described
 below. Use `python tools/check_python_deps.py` to confirm the Python
@@ -86,7 +91,7 @@ export N64_SOUL_DTYPE=fp16
 export N64_SOUL_KEEP_LAYERS=8
 
 TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
-cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --profile release --features embed_assets
+cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --release --features embed_assets
 ```
 
 Unset `N64_SOUL_KEEP_LAYERS` (or skip exporting entirely) to use the full model.

--- a/codex.md
+++ b/codex.md
@@ -9,16 +9,19 @@ rustup component add rust-src --toolchain nightly-2022-06-21
 
 # 2. Install cargo-n64 using the same nightly
 cargo +nightly-2022-06-21 install --git https://github.com/rust-console/cargo-n64.git --locked
-
-# 3. Add the target for the Nintendo 64
-rustup target add mips-nintendo64-none --toolchain nightly-2022-06-21
 ```
+
+`rustup` no longer provides a `mips-nintendo64-none` standard library, so
+attempting to add that target prints `toolchain 'nightly-2022-06-21-…' does not
+support target`. The build instead relies on the `rust-src` component together
+with `-Zbuild-std=core,alloc`, and `cargo-n64` bundles the target specification
+needed to invoke `rustc`.
 
 After these tools are installed, build the Rust project with:
 
 ```bash
 cd n64llm/n64-rust
-cargo +nightly-2022-06-21 n64 build --profile release --features embed_assets
+cargo +nightly-2022-06-21 -Z build-std=core,alloc n64 build --release --features embed_assets
 ```
 
 Enabling the `embed_assets` feature ensures the ROM includes the exported weights and manifest files.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -22,7 +22,6 @@ export N64SOUL_TOOLCHAIN=nightly-2022-06-21
 
 rustup toolchain install "$N64SOUL_TOOLCHAIN"
 rustup component add rust-src --toolchain "$N64SOUL_TOOLCHAIN"
-rustup target add mips-nintendo64-none --toolchain "$N64SOUL_TOOLCHAIN"
 
 # Install cargo-n64 with the pinned toolchain.
 N64SOUL_TOOLCHAIN="$N64SOUL_TOOLCHAIN" bash tools/install_cargo_n64.sh
@@ -30,6 +29,13 @@ N64SOUL_TOOLCHAIN="$N64SOUL_TOOLCHAIN" bash tools/install_cargo_n64.sh
 # Optional utilities can use stable.
 cargo install nust64
 ```
+
+Rustup no longer ships a prebuilt `mips-nintendo64-none` standard library for any
+host platform, so attempting `rustup target add mips-nintendo64-none` now fails
+with `toolchain 'nightly-2022-06-21-…' does not support target`. That is
+expected—`cargo-n64` bundles the target specification and the build uses
+`-Zbuild-std=core,alloc` to compile the required crates from `rust-src`, so no
+additional `rustup target` installation is necessary.
 
 The `tools/install_cargo_n64.sh` script first attempts a stock
 `cargo +"$N64SOUL_TOOLCHAIN" install cargo-n64`. If that fails it clones upstream,


### PR DESCRIPTION
## Summary
- drop the `rustup target add mips-nintendo64-none` step from the setup docs and README
- explain that recent toolchains no longer ship the target and that builds rely on `rust-src` plus `-Zbuild-std`
- align the documented build command with the script by using `--release`

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ca3d412348832397385997f9a26983