### PR TITLE
Remove manual release flag when invoking cargo-n64

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export N64_SOUL_DTYPE=fp16
 export N64_SOUL_KEEP_LAYERS=8
 
 TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
-cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --release --features embed_assets
+cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --features embed_assets
 ```
 
 Unset `N64_SOUL_KEEP_LAYERS` (or skip exporting entirely) to use the full model.
@@ -106,6 +106,9 @@ The following environment variables control the exporter:
 The build script always invokes `tools/export_gpt2_n64.py`. Adjust that script
 directly if you need to change export behavior; keeping a single exporter avoids
 stale artifacts from earlier experiments.
+
+`cargo-n64` automatically forwards `--release` to the inner `cargo build` call,
+so the wrapper will produce an optimized ROM without additional flags.
 
 Nintendo 64 ROMs also require the CIC-6102 boot code. Because that blob is
 copyrighted we cannot ship it; you must provide your own dump via

--- a/codex.md
+++ b/codex.md
@@ -21,7 +21,7 @@ After these tools are installed, build the Rust project with:
 
 ```bash
 cd n64llm/n64-rust
-cargo +nightly-2022-06-21 -Z build-std=core,alloc n64 build --release --features embed_assets
+cargo +nightly-2022-06-21 -Z build-std=core,alloc n64 build --features embed_assets
 ```
 
 Enabling the `embed_assets` feature ensures the ROM includes the exported weights and manifest files.
@@ -31,4 +31,7 @@ Building with `--features embed_assets` triggers the Python exporter defined in
 `build.rs`. Override the default settings with environment variables such as
 `N64_SOUL_MODEL_ID`, `N64_SOUL_DTYPE`, or `N64_SOUL_KEEP_LAYERS` before invoking
 `cargo-n64`. Set `N64_SOUL_SKIP_EXPORT=1` to reuse existing assets.
+
+`cargo-n64` automatically appends `--release` to the underlying `cargo build`
+command, so the resulting ROM uses optimized code paths by default.
 

--- a/scripts/export_and_test.sh
+++ b/scripts/export_and_test.sh
@@ -45,7 +45,7 @@ fi
 # Build the ROM. The build script exports and validates fresh weights.
 (
   cd "$ROM_DIR" && \
-  cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --release --features embed_assets
+  cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --features embed_assets
 )
 
 # Confirm the assets exist for downstream tooling.


### PR DESCRIPTION
## Summary
- drop the explicit `--release` flag from the export script so it matches the cargo-n64 CLI
- update README and codex docs to describe the new invocation and note that cargo-n64 enables release builds automatically

## Testing
- not run (requires Nintendo 64 toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca41891298832397e3e0c70e0c90dc