### PR TITLE
Fix cargo-n64 feature forwarding

### DIFF
--- a/codex.md
+++ b/codex.md
@@ -21,7 +21,7 @@ After these tools are installed, build the Rust project with:
 
 ```bash
 cd n64llm/n64-rust
-cargo +nightly-2022-06-21 -Z build-std=core,alloc n64 build --features embed_assets
+cargo +nightly-2022-06-21 -Z build-std=core,alloc n64 build -- --features embed_assets
 ```
 
 Enabling the `embed_assets` feature ensures the ROM includes the exported weights and manifest files.

--- a/scripts/emu_smoke.sh
+++ b/scripts/emu_smoke.sh
@@ -17,7 +17,7 @@ if [[ -z "$ROM_PATH" ]]; then
   echo "No ROM found; rebuilding with existing assets."
   (
     cd "$ROM_DIR" && \
-    N64_SOUL_SKIP_EXPORT=1 cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --profile release --features embed_assets
+    N64_SOUL_SKIP_EXPORT=1 cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build -- --profile release --features embed_assets
   )
   ROM_PATH=$(ls -1 $ROM_GLOB 2>/dev/null | head -n1 || true)
 fi

--- a/scripts/export_and_test.sh
+++ b/scripts/export_and_test.sh
@@ -45,7 +45,7 @@ fi
 # Build the ROM. The build script exports and validates fresh weights.
 (
   cd "$ROM_DIR" && \
-  cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --features embed_assets
+  cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build -- --features embed_assets
 )
 
 # Confirm the assets exist for downstream tooling.


### PR DESCRIPTION
## Summary
- ensure cargo-n64 invocations forward `--features` flags by passing them after a `--` separator
- update the Codex setup guide to document the corrected command line syntax

## Testing
- cargo test --lib --features host

------
https://chatgpt.com/codex/tasks/task_e_68ca42d0c2188323ad874dc9b6c3293b