### PR TITLE
Handle cargo-n64 IPL3 requirement in helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ Nintendo 64 ROMs also require the CIC-6102 boot code. Because that blob is
 copyrighted we cannot ship it; you must provide your own dump via
 `--ipl3 /path/to/cic6102.bin` or extract it from a known-good ROM with
 `--ipl3-from-rom /path/to/rom.z64` when running `cargo-n64`.
+Helper scripts such as `scripts/export_and_test.sh` and `scripts/emu_smoke.sh`
+forward the boot code automatically when one of the following environment
+variables is set before invocation:
+
+- `N64SOUL_IPL3_BIN` – absolute or relative path to a CIC-6102 dump.
+- `N64SOUL_IPL3_FROM_ROM` – path to a ROM image; `cargo-n64` extracts the
+  boot code automatically.
+- `N64SOUL_IPL3_DUMMY=1` – generate a zeroed placeholder so the ROM packages
+  successfully (non-bootable, useful for CI smoke tests).
 
 On success `cargo-n64` produces `target/n64/release/n64_gpt.z64`. The linker and
 configuration reserve roughly 1&nbsp;GiB of cart ROM space; the actual usable size

--- a/scripts/emu_smoke.sh
+++ b/scripts/emu_smoke.sh
@@ -15,9 +15,56 @@ cd "$ROOT_DIR"
 ROM_PATH=$(ls -1 $ROM_GLOB 2>/dev/null | head -n1 || true)
 if [[ -z "$ROM_PATH" ]]; then
   echo "No ROM found; rebuilding with existing assets."
+
+  IPL3_ARGS=()
+  if [[ -n "${N64SOUL_IPL3_BIN:-}" && -n "${N64SOUL_IPL3_FROM_ROM:-}" ]]; then
+    echo "error: set only one of N64SOUL_IPL3_BIN or N64SOUL_IPL3_FROM_ROM" >&2
+    exit 1
+  elif [[ -n "${N64SOUL_IPL3_BIN:-}" ]]; then
+    if [[ ! -f "${N64SOUL_IPL3_BIN}" ]]; then
+      echo "error: N64SOUL_IPL3_BIN does not exist: ${N64SOUL_IPL3_BIN}" >&2
+      exit 1
+    fi
+    IPL3_ARGS=(--ipl3 "${N64SOUL_IPL3_BIN}")
+  elif [[ -n "${N64SOUL_IPL3_FROM_ROM:-}" ]]; then
+    if [[ ! -f "${N64SOUL_IPL3_FROM_ROM}" ]]; then
+      echo "error: N64SOUL_IPL3_FROM_ROM does not exist: ${N64SOUL_IPL3_FROM_ROM}" >&2
+      exit 1
+    fi
+    IPL3_ARGS=(--ipl3-from-rom "${N64SOUL_IPL3_FROM_ROM}")
+  elif [[ "${N64SOUL_IPL3_DUMMY:-0}" == "1" ]]; then
+    if command -v python >/dev/null 2>&1; then
+      PYTHON_BIN=python
+    elif command -v python3 >/dev/null 2>&1; then
+      PYTHON_BIN=python3
+    else
+      echo "error: Python interpreter not found; required for dummy IPL3 generation." >&2
+      exit 1
+    fi
+
+    DUMMY_IPL3="$ROM_DIR/ipl3_dummy.bin"
+    if [[ ! -f "$DUMMY_IPL3" ]]; then
+      DUMMY_IPL3_PATH="$DUMMY_IPL3" "$PYTHON_BIN" - <<'PY'
+import os
+path = os.environ["DUMMY_IPL3_PATH"]
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "wb") as f:
+    f.write(b"\x00" * 4032)
+PY
+    fi
+    IPL3_ARGS=(--ipl3 "$DUMMY_IPL3")
+  else
+    cat <<'EOF2' >&2
+error: cargo-n64 now requires the CIC-6102 bootcode to rebuild the ROM.
+Set N64SOUL_IPL3_BIN to a cic6102 dump, N64SOUL_IPL3_FROM_ROM to a ROM image,
+or export N64SOUL_IPL3_DUMMY=1 to rebuild with a non-bootable placeholder.
+EOF2
+    exit 1
+  fi
+
   (
     cd "$ROM_DIR" && \
-    N64_SOUL_SKIP_EXPORT=1 cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build -- --profile release --features embed_assets
+    N64_SOUL_SKIP_EXPORT=1 cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build "${IPL3_ARGS[@]}" -- --profile release --features embed_assets
   )
   ROM_PATH=$(ls -1 $ROM_GLOB 2>/dev/null | head -n1 || true)
 fi


### PR DESCRIPTION
## Summary
- add IPL3 argument resolution to export_and_test and emu_smoke scripts, including a dummy bootcode option
- document the new N64SOUL_IPL3_* environment variables for helper scripts

## Testing
- bash -n scripts/export_and_test.sh
- bash -n scripts/emu_smoke.sh
- cargo test --lib --features host
- cargo test --test host_sanity --features host

------
https://chatgpt.com/codex/tasks/task_e_68ca464ef364832388010216f682ffaa