### PR TITLE
Default scripts to placeholder IPL3 when none provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,16 @@ copyrighted we cannot ship it; you must provide your own dump via
 `--ipl3 /path/to/cic6102.bin` or extract it from a known-good ROM with
 `--ipl3-from-rom /path/to/rom.z64` when running `cargo-n64`.
 Helper scripts such as `scripts/export_and_test.sh` and `scripts/emu_smoke.sh`
-forward the boot code automatically when one of the following environment
-variables is set before invocation:
+forward the boot code automatically when the related environment variables are
+set before invocation. When none of them are provided the scripts now generate a
+zeroed placeholder so the ROM packages successfully; set
+`N64SOUL_IPL3_DUMMY=0` to require a real bootcode dump.
 
 - `N64SOUL_IPL3_BIN` – absolute or relative path to a CIC-6102 dump.
 - `N64SOUL_IPL3_FROM_ROM` – path to a ROM image; `cargo-n64` extracts the
   boot code automatically.
-- `N64SOUL_IPL3_DUMMY=1` – generate a zeroed placeholder so the ROM packages
-  successfully (non-bootable, useful for CI smoke tests).
+- `N64SOUL_IPL3_DUMMY=1` – explicitly generate the placeholder (non-bootable,
+  useful for CI smoke tests).
 
 On success `cargo-n64` produces `target/n64/release/n64_gpt.z64`. The linker and
 configuration reserve roughly 1&nbsp;GiB of cart ROM space; the actual usable size

--- a/scripts/emu_smoke.sh
+++ b/scripts/emu_smoke.sh
@@ -17,6 +17,7 @@ if [[ -z "$ROM_PATH" ]]; then
   echo "No ROM found; rebuilding with existing assets."
 
   IPL3_ARGS=()
+  AUTO_DUMMY=0
   if [[ -n "${N64SOUL_IPL3_BIN:-}" && -n "${N64SOUL_IPL3_FROM_ROM:-}" ]]; then
     echo "error: set only one of N64SOUL_IPL3_BIN or N64SOUL_IPL3_FROM_ROM" >&2
     exit 1
@@ -32,34 +33,50 @@ if [[ -z "$ROM_PATH" ]]; then
       exit 1
     fi
     IPL3_ARGS=(--ipl3-from-rom "${N64SOUL_IPL3_FROM_ROM}")
-  elif [[ "${N64SOUL_IPL3_DUMMY:-0}" == "1" ]]; then
-    if command -v python >/dev/null 2>&1; then
-      PYTHON_BIN=python
-    elif command -v python3 >/dev/null 2>&1; then
-      PYTHON_BIN=python3
-    else
-      echo "error: Python interpreter not found; required for dummy IPL3 generation." >&2
-      exit 1
+  else
+    USE_DUMMY=0
+    if [[ -z "${N64SOUL_IPL3_DUMMY+x}" ]]; then
+      USE_DUMMY=1
+      AUTO_DUMMY=1
+    elif [[ "${N64SOUL_IPL3_DUMMY:-0}" == "1" ]]; then
+      USE_DUMMY=1
     fi
 
-    DUMMY_IPL3="$ROM_DIR/ipl3_dummy.bin"
-    if [[ ! -f "$DUMMY_IPL3" ]]; then
-      DUMMY_IPL3_PATH="$DUMMY_IPL3" "$PYTHON_BIN" - <<'PY'
+    if [[ "$USE_DUMMY" == "1" ]]; then
+      if command -v python >/dev/null 2>&1; then
+        PYTHON_BIN=python
+      elif command -v python3 >/dev/null 2>&1; then
+        PYTHON_BIN=python3
+      else
+        echo "error: Python interpreter not found; required for dummy IPL3 generation." >&2
+        exit 1
+      fi
+
+      DUMMY_IPL3="$ROM_DIR/ipl3_dummy.bin"
+      if [[ ! -f "$DUMMY_IPL3" ]]; then
+        DUMMY_IPL3_PATH="$DUMMY_IPL3" "$PYTHON_BIN" - <<'PY'
 import os
 path = os.environ["DUMMY_IPL3_PATH"]
 os.makedirs(os.path.dirname(path), exist_ok=True)
 with open(path, "wb") as f:
     f.write(b"\x00" * 4032)
 PY
-    fi
-    IPL3_ARGS=(--ipl3 "$DUMMY_IPL3")
-  else
-    cat <<'EOF2' >&2
+      fi
+      if [[ "$AUTO_DUMMY" == "1" ]]; then
+        cat <<'EOF2' >&2
+warning: no CIC-6102 bootcode provided; using a zeroed placeholder ROM header.
+Set N64SOUL_IPL3_BIN or N64SOUL_IPL3_FROM_ROM for a bootable image.
+EOF2
+      fi
+      IPL3_ARGS=(--ipl3 "$DUMMY_IPL3")
+    else
+      cat <<'EOF3' >&2
 error: cargo-n64 now requires the CIC-6102 bootcode to rebuild the ROM.
 Set N64SOUL_IPL3_BIN to a cic6102 dump, N64SOUL_IPL3_FROM_ROM to a ROM image,
 or export N64SOUL_IPL3_DUMMY=1 to rebuild with a non-bootable placeholder.
-EOF2
-    exit 1
+EOF3
+      exit 1
+    fi
   fi
 
   (


### PR DESCRIPTION
## Summary
- default the export and smoke-test helpers to generate a zeroed IPL3 placeholder when no bootcode variables are provided
- surface a warning explaining the placeholder fallback and keep strict validation when users opt out
- document the new default and how to require a real bootcode dump in the README

## Testing
- bash -n scripts/export_and_test.sh
- bash -n scripts/emu_smoke.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca4a26f49c832383f546065e24f04c