### PR TITLE
Update default nightly toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ repository.
 
 Install the Rust toolchain and helper utilities. See
 [docs/setup.md](docs/setup.md) for more detail. The project is pinned to the
-`nightly-2022-06-21` toolchain because newer nightlies no longer ship the
-`mips-nintendo64-none` target:
+`nightly-2024-10-01` toolchain so the bundled `cargo` understands the current
+`Cargo.lock` format while `cargo-n64` continues targeting
+`mips-nintendo64-none`:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-export N64SOUL_TOOLCHAIN=nightly-2022-06-21
+export N64SOUL_TOOLCHAIN=nightly-2024-10-01
 
 rustup toolchain install "$N64SOUL_TOOLCHAIN"
 rustup component add rust-src --toolchain "$N64SOUL_TOOLCHAIN"
@@ -62,7 +63,7 @@ cargo install nust64
 ```
 
 Rustup no longer publishes a `mips-nintendo64-none` standard library, so running
-`rustup target add` now reports `toolchain 'nightly-2022-06-21-…' does not
+`rustup target add` now reports `toolchain 'nightly-2024-10-01-…' does not
 support target`. That failure is expected—`cargo-n64` provides the target
 specification and the build uses `-Zbuild-std=core,alloc` to compile `core` and
 `alloc` from the `rust-src` component.
@@ -90,7 +91,7 @@ export N64_SOUL_MODEL_ID=distilgpt2
 export N64_SOUL_DTYPE=fp16
 export N64_SOUL_KEEP_LAYERS=8
 
-TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2024-10-01}"
 cargo +"$TOOLCHAIN" -Z build-std=core,alloc n64 build --features embed_assets
 ```
 

--- a/codex.md
+++ b/codex.md
@@ -1,18 +1,21 @@
 # Codex Environment Setup
 
 The project targets the `mips-nintendo64-none` architecture and requires a nightly Rust toolchain to build. The `cargo-n64` subcommand is also needed. The recommended install commands are below.
+The pinned nightly supplies a `cargo` new enough to understand the repository's
+`Cargo.lock` format while keeping Nintendo 64 support working through
+`cargo-n64`.
 
 ```bash
 # 1. Install a pinned nightly toolchain and rust-src
-rustup toolchain install nightly-2022-06-21
-rustup component add rust-src --toolchain nightly-2022-06-21
+rustup toolchain install nightly-2024-10-01
+rustup component add rust-src --toolchain nightly-2024-10-01
 
 # 2. Install cargo-n64 using the same nightly
-cargo +nightly-2022-06-21 install --git https://github.com/rust-console/cargo-n64.git --locked
+cargo +nightly-2024-10-01 install --git https://github.com/rust-console/cargo-n64.git --locked
 ```
 
 `rustup` no longer provides a `mips-nintendo64-none` standard library, so
-attempting to add that target prints `toolchain 'nightly-2022-06-21-…' does not
+attempting to add that target prints `toolchain 'nightly-2024-10-01-…' does not
 support target`. The build instead relies on the `rust-src` component together
 with `-Zbuild-std=core,alloc`, and `cargo-n64` bundles the target specification
 needed to invoke `rustc`.
@@ -21,7 +24,7 @@ After these tools are installed, build the Rust project with:
 
 ```bash
 cd n64llm/n64-rust
-cargo +nightly-2022-06-21 -Z build-std=core,alloc n64 build -- --features embed_assets
+cargo +nightly-2024-10-01 -Z build-std=core,alloc n64 build -- --features embed_assets
 ```
 
 Enabling the `embed_assets` feature ensures the ROM includes the exported weights and manifest files.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,11 +14,12 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 Then add the Nintendo 64 target and install the helper subcommand. The
 `mips-nintendo64-none` target disappeared from recent nightlies, so the build
-expects the pinned toolchain `nightly-2022-06-21`. Export the toolchain once so
-the helper scripts and docs remain in sync:
+expects the pinned toolchain `nightly-2024-10-01`. Export the toolchain once so
+the helper scripts and docs remain in sync, and because older toolchains ship a
+`cargo` that cannot parse the repository's lock file:
 
 ```bash
-export N64SOUL_TOOLCHAIN=nightly-2022-06-21
+export N64SOUL_TOOLCHAIN=nightly-2024-10-01
 
 rustup toolchain install "$N64SOUL_TOOLCHAIN"
 rustup component add rust-src --toolchain "$N64SOUL_TOOLCHAIN"
@@ -32,7 +33,7 @@ cargo install nust64
 
 Rustup no longer ships a prebuilt `mips-nintendo64-none` standard library for any
 host platform, so attempting `rustup target add mips-nintendo64-none` now fails
-with `toolchain 'nightly-2022-06-21-…' does not support target`. That is
+with `toolchain 'nightly-2024-10-01-…' does not support target`. That is
 expected—`cargo-n64` bundles the target specification and the build uses
 `-Zbuild-std=core,alloc` to compile the required crates from `rust-src`, so no
 additional `rustup target` installation is necessary.

--- a/scripts/emu_smoke.sh
+++ b/scripts/emu_smoke.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROM_DIR="$ROOT_DIR/n64llm/n64-rust"
 ASSETS="$ROM_DIR/assets"
 ROM_GLOB="$ROM_DIR/target"/n64/release/*.z64
-TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2024-10-01}"
 
 cd "$ROOT_DIR"
 

--- a/scripts/export_and_test.sh
+++ b/scripts/export_and_test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROM_DIR="$ROOT_DIR/n64llm/n64-rust"
 ASSETS_DIR="$ROM_DIR/assets"
-TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2024-10-01}"
 
 cd "$ROOT_DIR"
 

--- a/tools/install_cargo_n64.sh
+++ b/tools/install_cargo_n64.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO="https://github.com/rust-console/cargo-n64"
-TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2022-06-21}"
+TOOLCHAIN="${N64SOUL_TOOLCHAIN:-nightly-2024-10-01}"
 
 echo "[cargo-n64] Trying upstream main first…"
 if cargo +"$TOOLCHAIN" install cargo-n64 --git "$REPO" --branch main --locked; then


### PR DESCRIPTION
## Summary
- update helper scripts and documentation to pin the build to `nightly-2024-10-01`
- explain that the newer nightly is required so Cargo can read the repository's lock file

## Testing
- not run (custom Nintendo 64 toolchain unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca4b816b548323b09230aa575fe499