### PR TITLE
Fix stage1 memsize mutability and lint placement

### DIFF
--- a/n64llm/n64-rust/src/ipl3.rs
+++ b/n64llm/n64-rust/src/ipl3.rs
@@ -168,7 +168,7 @@ fn loader_base(memsize: i32, stage2_size: i32) -> *mut u8 {
 
 /// Compute the new stack pointer for Stage2.
 /// Adjust this as required by your memory layout.
-fn stack2_top(memsize: i32, _stage2_size: i32) -> u32 {
+fn stack2_top(_memsize: i32, _stage2_size: i32) -> u32 {
     // For example, use DMEM at 0xA4000000 plus an offset.
     0xA4000000 + 4096
 }
@@ -301,13 +301,13 @@ pub unsafe extern "C" fn stage1() -> ! {
     // In production, read MI_VERSION and RI_SELECT.
     let bbplayer = ((*MI_VERSION) & 0xF0) == 0xB0 || read_volatile(RI_SELECT) != 0;
 
-    let memsize: i32;
+    let mut memsize: i32;
     if !bbplayer && read_volatile(RI_SELECT) == 0 {
         memsize = rdram_init(|chip, last| unsafe { mem_bank_init(chip, last) });
     } else {
         // For iQue hardware, use the OS-provided memory size.
         // Read from the special location 0xA0000318.
-        let mut size_ptr = 0xA0000318 as *mut u32;
+        let size_ptr = 0xA0000318 as *mut u32;
         memsize = read_volatile(size_ptr) as i32;
         // Adjust for special cases if necessary.
         if memsize == 0x800000 {

--- a/n64llm/n64-rust/src/model/stream.rs
+++ b/n64llm/n64-rust/src/model/stream.rs
@@ -21,11 +21,13 @@ pub fn stream_layer<R: RomSource>(
     // Static 2×32 KiB (tweak in config if you like).
     static mut A: [u8; crate::config::STREAM_BLOCK_BYTES] = [0; crate::config::STREAM_BLOCK_BYTES];
     static mut B: [u8; crate::config::STREAM_BLOCK_BYTES] = [0; crate::config::STREAM_BLOCK_BYTES];
-    #[allow(static_mut_refs)]
-    let pre = unsafe {
-        let buf_a = slice::from_raw_parts_mut(addr_of_mut!(A) as *mut u8, A.len());
-        let buf_b = slice::from_raw_parts_mut(addr_of_mut!(B) as *mut u8, B.len());
-        Prefetcher::new(rom, layer.offset as u64, layer.len as u64, buf_a, buf_b)
+    let pre = {
+        #[allow(static_mut_refs)]
+        unsafe {
+            let buf_a = slice::from_raw_parts_mut(addr_of_mut!(A) as *mut u8, A.len());
+            let buf_b = slice::from_raw_parts_mut(addr_of_mut!(B) as *mut u8, B.len());
+            Prefetcher::new(rom, layer.offset as u64, layer.len as u64, buf_a, buf_b)
+        }
     };
     let mut pf = pre;
     let total = layer.len as u64;


### PR DESCRIPTION
## Summary
- allow the stage1 boot routine to assign a detected memory size by making the binding mutable and tidy the iQue pointer handling
- silence the unused stack parameter warning in stack2_top so the build stays clean
- scope the static_mut_refs allowance to the unsafe prefetch buffer setup in the streaming path

## Testing
- ./scripts/export_and_test.sh *(fails: missing torch/transformers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5462a41883238c2bcf4307d82c3b